### PR TITLE
Speed improvement for drawing smaller tiffs when zoomed in.

### DIFF
--- a/georaster-layer-for-leaflet.browserify.min.js
+++ b/georaster-layer-for-leaflet.browserify.min.js
@@ -1,4 +1,4 @@
-(function(){function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s}return e})()({1:[function(require,module,exports){
+(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
 let chroma = require("chroma-js");
 
 let L = window.L;
@@ -114,12 +114,16 @@ var GeoRasterLayer = L.GridLayer.extend({
 
         let resolution = this.options.resolution;
 
-        let number_of_rectangles_across = resolution;
-        let number_of_rectangles_down = resolution;
+        let raster_pixels_across = Math.ceil((xmax_of_tile - xmin_of_tile) / pixelWidth);
+        let raster_pixels_down = Math.ceil((ymax_of_tile - ymin_of_tile) / pixelHeight);
+        let number_of_rectangles_across = Math.min(resolution, raster_pixels_across);
+        let number_of_rectangles_down = Math.min(resolution, raster_pixels_down);
 
         let height_of_rectangle_in_pixels = this._tile_height / number_of_rectangles_down;
+        let height_of_rectangle_in_pixels_int = Math.ceil(height_of_rectangle_in_pixels);
         //if (debug_level >= 1) console.log("height_of_rectangle_in_pixels:", height_of_rectangle_in_pixels);
         let width_of_rectangle_in_pixels = this._tile_width / number_of_rectangles_across;
+        let width_of_rectangle_in_pixels_int = Math.ceil(width_of_rectangle_in_pixels);
         //if (debug_level >= 1) console.log("width_of_rectangle:", width_of_rectangle_in_pixels);
 
         let height_of_rectangle_in_degrees = ( ymax_of_tile - ymin_of_tile ) / number_of_rectangles_down;
@@ -136,20 +140,22 @@ var GeoRasterLayer = L.GridLayer.extend({
         let tileNwPoint = coords.scaleBy(tileSize);
 
         for (let h = 0; h < number_of_rectangles_down; h++) {
-            let latWestPoint = L.point(tileNwPoint.x, tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels);
+            let y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
+            let latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
             let latWest = map.unproject(latWestPoint, coords.z);
             let lat = latWest.lat;
             //if (debug_level >= 2) console.log("lat:", lat);
             if (lat > ymin && lat < ymax) {
+              let y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
+              let y_in_raster_pixels = Math.floor( (ymax - lat) / pixelHeight );
               for (let w = 0; w < number_of_rectangles_across; w++) {
-                let latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels);
+                let latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
                 let latLng = map.unproject(latLngPoint, coords.z);
                 let lng = latLng.lng;
                 //if (debug_level >= 2) console.log("lng:", lng);
                 if (lng > xmin && lng < xmax) {
                     //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#00FF00"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
                     let x_in_raster_pixels = Math.floor( (lng - xmin) / pixelWidth );
-                    let y_in_raster_pixels = Math.floor( (ymax - lat) / pixelHeight );
 
                     if (debug_level >= 1) time_started_reading_rasters = performance.now();
                     let values = rasters.map(raster => raster[y_in_raster_pixels][x_in_raster_pixels]);
@@ -177,10 +183,10 @@ var GeoRasterLayer = L.GridLayer.extend({
                     if (color) {
                         context.fillStyle = color;
                         if (debug_level >= 1) time_started_filling_rect = performance.now();
-                        context.fillRect(w * width_of_rectangle_in_pixels, h * height_of_rectangle_in_pixels, width_of_rectangle_in_pixels, height_of_rectangle_in_pixels);
+                        context.fillRect(Math.round(w * width_of_rectangle_in_pixels), y_in_tile_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int);
                         if (debug_level >= 1) duration_filling_rects += performance.now() - time_started_filling_rect;
                     }
-                    //if (debug_level >= 2) console.log("filling:", [w * width_of_rectangle_in_pixels, h * height_of_rectangle_in_pixels, width_of_rectangle_in_pixels, height_of_rectangle_in_pixels]);
+                    //if (debug_level >= 2) console.log("filling:", [w * width_of_rectangle_in_pixels, rect_y_in_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int]);
                     //if (debug_level >= 2) console.log("with color:", color);
                     //if (debug_level >= 2) console.log("with context:", context);
                 } else {


### PR DESCRIPTION
When using a high resolution (256, being 1 pixel rectangles if tiles are 256x256) and zooming in, rendering the georaster-layer becomes slow, taking a few seconds per redraw.
For smaller TIFFs, too much computation is done, as at some moment each TIFF pixel will be painted as multiple pixels on the screen. And with resolution 256, each screen pixel is painted separately.

In that case, it would not need to compute each screen pixel anymore, but could revert to painting each TIFF pixel.

With this code fix, for 500x500 pixel TIFF the application then remains responsive.

Some counter-arguments could be:

- Result may become a bit less accurate, due to rounding to integer pixel sizes.
- For TIFFs that are not geo-rectified, using rectangular fill areas may also give a less accurate image than with computing each screen pixel individually. (not sure if the current code would support non-georectified tiffs by the way, I don't use that).

Some details for the attached code:

- If I do not round the values in the fillRect call, I get stripes in the resulting image, probably because it is not painting on some pixels.
- I round the pixel size  using ceil, to be sure the rectangle is large enough to fit to the next rectangle, possibly overlapping 1 pixel.