### PR TITLE
use new georaster getValues method for better COG support

### DIFF
--- a/georaster-layer-for-leaflet.browserify.min.js
+++ b/georaster-layer-for-leaflet.browserify.min.js
@@ -75,24 +75,22 @@ var GeoRasterLayer = L.GridLayer.extend({
         let y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
         let latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
         let latWest = map.unproject(latWestPoint, coords.z);
-        let lat = latWest.lat;
+        let { lat } = latWest;
         let y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
         let y_in_raster_pixels = Math.floor( (ymax - lat) / pixelHeight );
 
         let latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
         let latLng = map.unproject(latLngPoint, coords.z);
-        let lng = latLng.lng;
+        let { lng } = latLng;
         let x_in_raster_pixels = Math.floor( (lng - xmin) / pixelWidth );
 
         return [y_in_raster_pixels, x_in_raster_pixels];
       }
 
       let result = raster_coords_for_tile_coords(0, 0);
-      let min_y = result[0];
-      let min_x = result[1];
+      let [ min_y, min_x ] = result;
       result = raster_coords_for_tile_coords(number_of_rectangles_down - 1, number_of_rectangles_across - 1);
-      let max_y = result[0];
-      let max_x = result[1];
+      let [ max_y, max_x ] = result;
 
       // careful not to flip min_y/max_y here
       let tile_values = await this.georaster.getValues(min_x, min_y, max_x, max_y, number_of_rectangles_across, number_of_rectangles_down);

--- a/georaster-layer-for-leaflet.browserify.min.js
+++ b/georaster-layer-for-leaflet.browserify.min.js
@@ -57,9 +57,56 @@ var GeoRasterLayer = L.GridLayer.extend({
             console.error("ERROR initializing GeoTIFFLayer", error);
         }
     },
+    
+    getRasters: async function(
+          map, tileNwPoint, height_of_rectangle_in_pixels, width_of_rectangle_in_pixels,
+          coords, pixelHeight, pixelWidth, number_of_rectangles_across, number_of_rectangles_down, ymax, xmin) {
+      // called if georaster was constructed from URL and we need to get
+      // data separately for each tile
+      // aka "COG mode"
+
+      const raster_coords_for_tile_coords = function(h, w) {
+        let y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
+        let latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
+        let latWest = map.unproject(latWestPoint, coords.z);
+        let lat = latWest.lat;
+        let y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
+        let y_in_raster_pixels = Math.floor( (ymax - lat) / pixelHeight );
+
+        let latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
+        let latLng = map.unproject(latLngPoint, coords.z);
+        let lng = latLng.lng;
+        let x_in_raster_pixels = Math.floor( (lng - xmin) / pixelWidth );
+
+        return [y_in_raster_pixels, x_in_raster_pixels];
+      }
+
+      let result = raster_coords_for_tile_coords(0, 0);
+      let min_y = result[0];
+      let min_x = result[1];
+      result = raster_coords_for_tile_coords(number_of_rectangles_down - 1, number_of_rectangles_across - 1);
+      let max_y = result[0];
+      let max_x = result[1];
+
+      // careful not to flip min_y/max_y here
+      let tile_values = await this.georaster.getValues(min_x, min_y, max_x, max_y, number_of_rectangles_across, number_of_rectangles_down);
+
+      let tile_values_2d = tile_values.map(valuesInOneDimension => {
+        const valuesInTwoDimensions = [];
+        const width = number_of_rectangles_across;
+        const height = number_of_rectangles_down;
+        for (let y = 0; y < height; y++) {
+          const start = y * width;
+          const end = start + width;
+          valuesInTwoDimensions.push(valuesInOneDimension.slice(start, end));
+        }
+        return valuesInTwoDimensions;
+      });
+
+      return tile_values_2d;
+    },
 
     createTile: function(coords, done) {
-    // createTile: function(coords) {
 
         var error;
 
@@ -144,97 +191,12 @@ var GeoRasterLayer = L.GridLayer.extend({
 
         // render asynchronously so tiles show up as they finish instead of all at once (which blocks the UI)
         setTimeout(async function () {
-            let min_x = Number.MAX_SAFE_INTEGER;
-            let max_x = 0;
-            let min_y = Number.MAX_SAFE_INTEGER;
-            let max_y = 0;
-
-            let samples_per_pixel = null;
-            let tile_values = [];
-            if (rasters) {
-              samples_per_pixel = rasters.length;
-              for (let samp_i = 0; samp_i < samples_per_pixel; samp_i++) {
-                tile_values.push([]);
-              }
-            }
-
-            const push_value = function(value_array, values) {
-                for (let val_i = 0; val_i < samples_per_pixel; val_i++) {
-                  let value = no_data_value;
-                  if (values) {
-                    value = values[val_i];
-                  }
-                  value_array[val_i].push(value)
-                }
-            }
-
-            for (let h = 0; h < number_of_rectangles_down; h++) {
-                let y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
-                let latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
-                let latWest = map.unproject(latWestPoint, coords.z);
-                let lat = latWest.lat;
-                //if (debug_level >= 2) console.log("lat:", lat);
-                if ((!rasters) || (lat > ymin && lat < ymax)) {
-                  let y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
-                  let y_in_raster_pixels = Math.floor( (ymax - lat) / pixelHeight );
-                  for (let w = 0; w < number_of_rectangles_across; w++) {
-                    let latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
-                    let latLng = map.unproject(latLngPoint, coords.z);
-                    let lng = latLng.lng;
-                    //if (debug_level >= 2) console.log("lng:", lng);
-                    if ((!rasters) || (lng > xmin && lng < xmax)) {
-                        //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#00FF00"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
-                        let x_in_raster_pixels = Math.floor( (lng - xmin) / pixelWidth );
-
-                        if (debug_level >= 1) time_started_reading_rasters = performance.now();
-                        if (rasters) {
-                          let values = rasters.map(raster => raster[y_in_raster_pixels][x_in_raster_pixels]);
-                          push_value(tile_values, values);
-                        } else {
-                          if (y_in_raster_pixels < min_y) {
-                            min_y = y_in_raster_pixels;
-                          }
-                          if (y_in_raster_pixels > max_y) {
-                            max_y = y_in_raster_pixels;
-                          }
-                          if (x_in_raster_pixels < min_x) {
-                            min_x = x_in_raster_pixels;
-                          }
-                          if (x_in_raster_pixels > max_x) {
-                            max_x = x_in_raster_pixels;
-                          }
-                        }
-                    } else {
-                        if (rasters) {
-                          push_value(tile_values);
-                        }
-                    }
-                  }
-                } else {
-                    if (rasters) {
-                      for (let w = 0; w < number_of_rectangles_across; w++) {
-                        push_value(tile_values);
-                      }
-                    }
-                }
-            }
-
+            let tile_rasters = null;
             if (!rasters) {
-              // careful not to flip min_y/max_y here
-              tile_values = await this.georaster.getValues(min_x, min_y, max_x, max_y, number_of_rectangles_across, number_of_rectangles_down);
+              tile_rasters = await this.getRasters(
+                map, tileNwPoint, height_of_rectangle_in_pixels, width_of_rectangle_in_pixels, coords, pixelHeight, pixelWidth,
+                number_of_rectangles_across, number_of_rectangles_down, ymax, xmin);
             }
-
-            let tile_values_2d = tile_values.map(valuesInOneDimension => {
-              const valuesInTwoDimensions = [];
-              const width = number_of_rectangles_across;
-              const height = number_of_rectangles_down;
-              for (let y = 0; y < height; y++) {
-                const start = y * width;
-                const end = start + width;
-                valuesInTwoDimensions.push(valuesInOneDimension.slice(start, end));
-              }
-              return valuesInTwoDimensions;
-            });
 
             for (let h = 0; h < number_of_rectangles_down; h++) {
                 let y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
@@ -255,8 +217,16 @@ var GeoRasterLayer = L.GridLayer.extend({
                         let x_in_raster_pixels = Math.floor( (lng - xmin) / pixelWidth );
 
                         if (debug_level >= 1) time_started_reading_rasters = performance.now();
-                        let values = tile_values_2d.map(raster => raster[h][w]);
+                        let values = null;
+                        if (tile_rasters) {
+                          // get value from array specific to this tile
+                          values = tile_rasters.map(raster => raster[h][w]);
+                        } else {
+                          // get value from array with data for entire raster
+                          values = rasters.map(raster => raster[y_in_raster_pixels][x_in_raster_pixels]);
+                        }
                         if (debug_level >= 1) duration_reading_rasters += performance.now() - time_started_reading_rasters;
+
                         let color = null;
                         if(this.options.pixelValueToColorFn) {
                           color = this.options.pixelValueToColorFn(values[0]);

--- a/georaster-layer-for-leaflet.browserify.min.js
+++ b/georaster-layer-for-leaflet.browserify.min.js
@@ -1,4 +1,4 @@
-(function(){function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s}return e})()({1:[function(require,module,exports){
+(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
 let chroma = require("chroma-js");
 
 let L = window.L;
@@ -58,7 +58,10 @@ var GeoRasterLayer = L.GridLayer.extend({
         }
     },
 
-    createTile: function(coords) {
+    createTile: function(coords, done) {
+    // createTile: function(coords) {
+
+        var error;
 
         let debug_level = 0;
 
@@ -139,71 +142,174 @@ var GeoRasterLayer = L.GridLayer.extend({
         let tileSize = this.getTileSize();
         let tileNwPoint = coords.scaleBy(tileSize);
 
-        for (let h = 0; h < number_of_rectangles_down; h++) {
-            let y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
-            let latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
-            let latWest = map.unproject(latWestPoint, coords.z);
-            let lat = latWest.lat;
-            //if (debug_level >= 2) console.log("lat:", lat);
-            if (lat > ymin && lat < ymax) {
-              let y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
-              let y_in_raster_pixels = Math.floor( (ymax - lat) / pixelHeight );
-              for (let w = 0; w < number_of_rectangles_across; w++) {
-                let latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
-                let latLng = map.unproject(latLngPoint, coords.z);
-                let lng = latLng.lng;
-                //if (debug_level >= 2) console.log("lng:", lng);
-                if (lng > xmin && lng < xmax) {
-                    //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#00FF00"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
-                    let x_in_raster_pixels = Math.floor( (lng - xmin) / pixelWidth );
+        // render asynchronously so tiles show up as they finish instead of all at once (which blocks the UI)
+        setTimeout(async function () {
+            let min_x = Number.MAX_SAFE_INTEGER;
+            let max_x = 0;
+            let min_y = Number.MAX_SAFE_INTEGER;
+            let max_y = 0;
 
-                    if (debug_level >= 1) time_started_reading_rasters = performance.now();
-                    let values = rasters.map(raster => raster[y_in_raster_pixels][x_in_raster_pixels]);
-                    if (debug_level >= 1) duration_reading_rasters += performance.now() - time_started_reading_rasters;
-                    let color = null;
-                    if(this.options.pixelValueToColorFn) {
-                      color = this.options.pixelValueToColorFn(values[0]);
-                    } else {
-                      let number_of_values = values.length;
-                      if (number_of_values == 1) {
-                          let value = values[0];
-                          if (value != no_data_value) {
-                              color = scale( (values[0] - mins[0]) / ranges[0] ).hex();
-                          }
-                      } else if (number_of_values == 2) {
-                      } else if (number_of_values == 3) {
-                          if (values[0] != no_data_value) {
-                              color = "rgb(" + values[0] + "," + values[1] + "," + values[2] + ")";
-                          }
-                      }
-                    }
-                    //let colors = ["red", "green", "blue", "pink", "purple", "orange"];
-                    //let color = colors[Math.round(colors.length * Math.random())];
-                    //context.fillStyle = this.getColor(color);
-                    if (color) {
-                        context.fillStyle = color;
-                        if (debug_level >= 1) time_started_filling_rect = performance.now();
-                        context.fillRect(Math.round(w * width_of_rectangle_in_pixels), y_in_tile_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int);
-                        if (debug_level >= 1) duration_filling_rects += performance.now() - time_started_filling_rect;
-                    }
-                    //if (debug_level >= 2) console.log("filling:", [w * width_of_rectangle_in_pixels, rect_y_in_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int]);
-                    //if (debug_level >= 2) console.log("with color:", color);
-                    //if (debug_level >= 2) console.log("with context:", context);
-                } else {
-                    //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#FF0000"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
-                }
+            let samples_per_pixel = null;
+            let tile_values = [];
+            if (rasters) {
+              samples_per_pixel = rasters.length;
+              for (let samp_i = 0; samp_i < samples_per_pixel; samp_i++) {
+                tile_values.push([]);
               }
             }
-        }
+
+            const push_value = function(value_array, values) {
+                for (let val_i = 0; val_i < samples_per_pixel; val_i++) {
+                  let value = no_data_value;
+                  if (values) {
+                    value = values[val_i];
+                  }
+                  value_array[val_i].push(value)
+                }
+            }
+
+            for (let h = 0; h < number_of_rectangles_down; h++) {
+                let y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
+                let latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
+                let latWest = map.unproject(latWestPoint, coords.z);
+                let lat = latWest.lat;
+                //if (debug_level >= 2) console.log("lat:", lat);
+                if ((!rasters) || (lat > ymin && lat < ymax)) {
+                  let y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
+                  let y_in_raster_pixels = Math.floor( (ymax - lat) / pixelHeight );
+                  for (let w = 0; w < number_of_rectangles_across; w++) {
+                    let latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
+                    let latLng = map.unproject(latLngPoint, coords.z);
+                    let lng = latLng.lng;
+                    //if (debug_level >= 2) console.log("lng:", lng);
+                    if ((!rasters) || (lng > xmin && lng < xmax)) {
+                        //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#00FF00"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
+                        let x_in_raster_pixels = Math.floor( (lng - xmin) / pixelWidth );
+
+                        if (debug_level >= 1) time_started_reading_rasters = performance.now();
+                        if (rasters) {
+                          let values = rasters.map(raster => raster[y_in_raster_pixels][x_in_raster_pixels]);
+                          push_value(tile_values, values);
+                        } else {
+                          if (y_in_raster_pixels < min_y) {
+                            min_y = y_in_raster_pixels;
+                          }
+                          if (y_in_raster_pixels > max_y) {
+                            max_y = y_in_raster_pixels;
+                          }
+                          if (x_in_raster_pixels < min_x) {
+                            min_x = x_in_raster_pixels;
+                          }
+                          if (x_in_raster_pixels > max_x) {
+                            max_x = x_in_raster_pixels;
+                          }
+                        }
+                    } else {
+                        if (rasters) {
+                          push_value(tile_values);
+                        }
+                    }
+                  }
+                } else {
+                    if (rasters) {
+                      for (let w = 0; w < number_of_rectangles_across; w++) {
+                        push_value(tile_values);
+                      }
+                    }
+                }
+            }
+
+            if (!rasters) {
+              // careful not to flip min_y/max_y here
+              tile_values = await this.georaster.getValues(min_x, min_y, max_x, max_y, number_of_rectangles_across, number_of_rectangles_down);
+            }
+
+            let tile_values_2d = tile_values.map(valuesInOneDimension => {
+              const valuesInTwoDimensions = [];
+              const width = number_of_rectangles_across;
+              const height = number_of_rectangles_down;
+              for (let y = 0; y < height; y++) {
+                const start = y * width;
+                const end = start + width;
+                valuesInTwoDimensions.push(valuesInOneDimension.slice(start, end));
+              }
+              return valuesInTwoDimensions;
+            });
+
+            for (let h = 0; h < number_of_rectangles_down; h++) {
+                let y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
+                let latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
+                let latWest = map.unproject(latWestPoint, coords.z);
+                let lat = latWest.lat;
+                //if (debug_level >= 2) console.log("lat:", lat);
+                if (lat > ymin && lat < ymax) {
+                  let y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
+                  let y_in_raster_pixels = Math.floor( (ymax - lat) / pixelHeight );
+                  for (let w = 0; w < number_of_rectangles_across; w++) {
+                    let latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
+                    let latLng = map.unproject(latLngPoint, coords.z);
+                    let lng = latLng.lng;
+                    //if (debug_level >= 2) console.log("lng:", lng);
+                    if (lng > xmin && lng < xmax) {
+                        //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#00FF00"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
+                        let x_in_raster_pixels = Math.floor( (lng - xmin) / pixelWidth );
+
+                        if (debug_level >= 1) time_started_reading_rasters = performance.now();
+                        let values = tile_values_2d.map(raster => raster[h][w]);
+                        if (debug_level >= 1) duration_reading_rasters += performance.now() - time_started_reading_rasters;
+                        let color = null;
+                        if(this.options.pixelValueToColorFn) {
+                          color = this.options.pixelValueToColorFn(values[0]);
+                        } else {
+                          let number_of_values = values.length;
+                          if (number_of_values == 1) {
+                              let value = values[0];
+                              if (ranges) {
+                                if (value != no_data_value) {
+                                    color = scale( (values[0] - mins[0]) / ranges[0] ).hex();
+                                }
+                              } else {
+                                // TODO not sure what to do here - For COG, we don't know the min max of the full raster.
+                                // Currently I'm just hardcoding to a value that works for the LS8 raster I'm looking at.
+                                color = scale( (values[0] - 10798) / (16110-10798)).hex();
+                              }
+                          } else if (number_of_values == 2) {
+                          } else if (number_of_values == 3) {
+                              if (values[0] != no_data_value) {
+                                  color = "rgb(" + values[0] + "," + values[1] + "," + values[2] + ")";
+                              }
+                          }
+                        }
+                        //let colors = ["red", "green", "blue", "pink", "purple", "orange"];
+                        //let color = colors[Math.round(colors.length * Math.random())];
+                        //context.fillStyle = this.getColor(color);
+                        if (color) {
+                            context.fillStyle = color;
+                            if (debug_level >= 1) time_started_filling_rect = performance.now();
+                            context.fillRect(Math.round(w * width_of_rectangle_in_pixels), y_in_tile_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int);
+                            if (debug_level >= 1) duration_filling_rects += performance.now() - time_started_filling_rect;
+                        }
+                        //if (debug_level >= 2) console.log("filling:", [w * width_of_rectangle_in_pixels, rect_y_in_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int]);
+                        //if (debug_level >= 2) console.log("with color:", color);
+                        //if (debug_level >= 2) console.log("with context:", context);
+                    } else {
+                        //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#FF0000"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
+                    }
+                  }
+                }
+            }
 
 
-        if (debug_level >= 1) {
-            let duration = performance.now() - start_time;
-            console.log("creating tile took ", duration, "milliseconds");
-            console.log("took", duration_reading_rasters, "milliseconds to read rasters, which is ", Math.round(duration_reading_rasters / duration * 100), "percentage of the total time");
-            console.log("took", duration_filling_rects, "milliseconds to fill rects, which is ", Math.round(duration_filling_rects / duration * 100), "percentage of the total time");
-        }
-        //if (debug_level >= 1) console.groupEnd();
+            if (debug_level >= 1) {
+                let duration = performance.now() - start_time;
+                console.log("creating tile took ", duration, "milliseconds");
+                console.log("took", duration_reading_rasters, "milliseconds to read rasters, which is ", Math.round(duration_reading_rasters / duration * 100), "percentage of the total time");
+                console.log("took", duration_filling_rects, "milliseconds to fill rects, which is ", Math.round(duration_filling_rects / duration * 100), "percentage of the total time");
+            }
+            //if (debug_level >= 1) console.groupEnd();
+
+            done(error, tile);
+        }.bind(this), 0);
 
         // return the tile so it can be rendered on screen
         return tile;
@@ -384,7 +490,7 @@ if (typeof window !== "undefined") {
     root.chroma = chroma;
   }
 
-  chroma.version = '1.4.0';
+  chroma.version = '1.4.1';
 
   _input = {};
 
@@ -2350,7 +2456,7 @@ if (typeof window !== "undefined") {
       if (bypassMap == null) {
         bypassMap = false;
       }
-      if (isNaN(val)) {
+      if (isNaN(val) || val === null) {
         return _nacol;
       }
       if (!bypassMap) {
@@ -2588,6 +2694,14 @@ if (typeof window !== "undefined") {
         return f;
       } else {
         return _gamma;
+      }
+    };
+    f.nodata = function(d) {
+      if (d != null) {
+        _nacol = chroma(d);
+        return f;
+      } else {
+        return _nacol;
       }
     };
     return f;

--- a/georaster-layer-for-leaflet.browserify.min.js
+++ b/georaster-layer-for-leaflet.browserify.min.js
@@ -37,6 +37,12 @@ var GeoRasterLayer = L.GridLayer.extend({
             this._xmax = georaster.xmax;
             this._ymax = georaster.ymax;
 
+            if (georaster.sourceType === 'url' && georaster.numberOfRasters === 1 && !options.pixelValueToColorFn) {
+              // For COG, we can't determine a data min max for color scaling,
+              // so pixelValueToColorFn is required.
+              throw "pixelValueToColorFn is a required option for single-band rasters initialized via URL";
+            }
+
             console.log("georaster.ymin:", georaster.ymin);
             let southWest = L.latLng(georaster.ymin, georaster.xmin);
             let northEast = L.latLng(georaster.ymax, georaster.xmax);
@@ -234,14 +240,8 @@ var GeoRasterLayer = L.GridLayer.extend({
                           let number_of_values = values.length;
                           if (number_of_values == 1) {
                               let value = values[0];
-                              if (ranges) {
-                                if (value != no_data_value) {
-                                    color = scale( (values[0] - mins[0]) / ranges[0] ).hex();
-                                }
-                              } else {
-                                // TODO not sure what to do here - For COG, we don't know the min max of the full raster.
-                                // Currently I'm just hardcoding to a value that works for the LS8 raster I'm looking at.
-                                color = scale( (values[0] - 10798) / (16110-10798)).hex();
+                              if (value != no_data_value) {
+                                  color = scale( (values[0] - mins[0]) / ranges[0] ).hex();
                               }
                           } else if (number_of_values == 2) {
                           } else if (number_of_values == 3) {

--- a/georaster-layer-for-leaflet.bundle.js
+++ b/georaster-layer-for-leaflet.bundle.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
+
 var chroma = require("chroma-js");
 
 var L = window.L;
@@ -74,25 +76,36 @@ var GeoRasterLayer = L.GridLayer.extend({
             var latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
             var latWest = map.unproject(latWestPoint, coords.z);
             var lat = latWest.lat;
+
             var y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
             var y_in_raster_pixels = Math.floor((ymax - lat) / pixelHeight);
 
             var latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
             var latLng = map.unproject(latLngPoint, coords.z);
             var lng = latLng.lng;
+
             var x_in_raster_pixels = Math.floor((lng - xmin) / pixelWidth);
 
             return [y_in_raster_pixels, x_in_raster_pixels];
         };
 
         var result = raster_coords_for_tile_coords(0, 0);
-        var min_y = result[0];
-        var min_x = result[1];
+
+        var _result = result,
+            _result2 = _slicedToArray(_result, 2),
+            min_y = _result2[0],
+            min_x = _result2[1];
+
         result = raster_coords_for_tile_coords(number_of_rectangles_down - 1, number_of_rectangles_across - 1);
-        var max_y = result[0];
-        var max_x = result[1];
+
+        var _result3 = result,
+            _result4 = _slicedToArray(_result3, 2),
+            max_y = _result4[0],
+            max_x = _result4[1];
 
         // careful not to flip min_y/max_y here
+
+
         var tile_values = await this.georaster.getValues(min_x, min_y, max_x, max_y, number_of_rectangles_across, number_of_rectangles_down);
 
         var tile_values_2d = tile_values.map(function (valuesInOneDimension) {

--- a/georaster-layer-for-leaflet.bundle.js
+++ b/georaster-layer-for-leaflet.bundle.js
@@ -6,348 +6,312 @@ var L = window.L;
 
 var GeoRasterLayer = L.GridLayer.extend({
 
-  initialize: function initialize(options) {
-    try {
-      console.log("starting GeoRasterLayer.initialize with", options);
+    initialize: function initialize(options) {
+        try {
+            console.log("starting GeoRasterLayer.initialize with", options);
 
-      if (!options.keepBuffer) options.keepBuffer = 25;
+            if (!options.keepBuffer) options.keepBuffer = 25;
 
-      if (!options.resolution) options.resolution = Math.pow(2, 5);
+            if (!options.resolution) options.resolution = Math.pow(2, 5);
 
-      if (options.updateWhenZooming === undefined) options.updateWhenZooming = false;
+            if (options.updateWhenZooming === undefined) options.updateWhenZooming = false;
 
-      var georaster = options.georaster;
-      this.georaster = georaster;
+            var georaster = options.georaster;
+            this.georaster = georaster;
 
-      this.scale = chroma.scale();
+            this.scale = chroma.scale();
 
-      /*
-          Unpacking values for use later.
-          We do this in order to increase speed.
-      */
-      this._maxs = georaster.maxs;
-      this._mins = georaster.mins;
-      this._ranges = georaster.ranges;
-      this._no_data_value = georaster.noDataValue;
-      this._pixelWidth = georaster.pixelWidth;
-      this._pixelHeight = georaster.pixelHeight;
-      this._rasters = georaster.values;
-      this._tiff_width = georaster.width;
-      this._xmin = georaster.xmin;
-      this._ymin = georaster.ymin;
-      this._xmax = georaster.xmax;
-      this._ymax = georaster.ymax;
+            /*
+                Unpacking values for use later.
+                We do this in order to increase speed.
+            */
+            this._maxs = georaster.maxs;
+            this._mins = georaster.mins;
+            this._ranges = georaster.ranges;
+            this._no_data_value = georaster.noDataValue;
+            this._pixelWidth = georaster.pixelWidth;
+            this._pixelHeight = georaster.pixelHeight;
+            this._rasters = georaster.values;
+            this._tiff_width = georaster.width;
+            this._xmin = georaster.xmin;
+            this._ymin = georaster.ymin;
+            this._xmax = georaster.xmax;
+            this._ymax = georaster.ymax;
 
-      console.log("georaster.ymin:", georaster.ymin);
-      var southWest = L.latLng(georaster.ymin, georaster.xmin);
-      var northEast = L.latLng(georaster.ymax, georaster.xmax);
-      this._bounds = L.latLngBounds(southWest, northEast);
-      console.log("this._bounds:", this._bounds);
-      options.bounds = this._bounds;
-      L.setOptions(this, options);
+            console.log("georaster.ymin:", georaster.ymin);
+            var southWest = L.latLng(georaster.ymin, georaster.xmin);
+            var northEast = L.latLng(georaster.ymax, georaster.xmax);
+            this._bounds = L.latLngBounds(southWest, northEast);
+            console.log("this._bounds:", this._bounds);
+            options.bounds = this._bounds;
+            L.setOptions(this, options);
 
-      /*
-          Caching the constant tile size, so we don't recalculate everytime we
-          create a new tile
-      */
-      var tileSize = this.getTileSize();
-      this._tile_height = tileSize.y;
-      this._tile_width = tileSize.x;
-    } catch (error) {
-      console.error("ERROR initializing GeoTIFFLayer", error);
-    }
-  },
-
-  createTile: function createTile(coords, done) {
-    // createTile: function(coords) {
-
-    var error;
-
-    var debug_level = 0;
-
-    if (debug_level >= 1) {
-      var start_time = performance.now();
-      var duration_reading_rasters = 0;
-      var time_started_reading_rasters;
-      var time_started_filling_rect;
-      var duration_filling_rects = 0;
-    }
-
-    /*
-        Unpacking values for use later.
-        We do this in order to increase speed.
-    */
-    var maxs = this._maxs;
-    var mins = this._mins;
-    var ranges = this._ranges;
-    var no_data_value = this._no_data_value;
-    var pixelWidth = this._pixelWidth;
-    var pixelHeight = this._pixelHeight;
-    var rasters = this._rasters;
-    var scale = this.scale;
-    var tiff_width = this._tiff_width;
-    var xmin = this._xmin;
-    var ymin = this._ymin;
-    var xmax = this._xmax;
-    var ymax = this._ymax;
-
-    //if (debug_level >= 1) console.group();
-
-    //if (debug_level >= 1) console.log("starting createTile with coords:", coords);
-
-
-    // create a <canvas> element for drawing
-    var tile = L.DomUtil.create('canvas', 'leaflet-tile');
-    tile.height = this._tile_height;
-    tile.width = this._tile_width;
-
-    // get a canvas context and draw something on it using coords.x, coords.y and coords.z
-    var context = tile.getContext('2d');
-
-    var bounds = this._tileCoordsToBounds(coords);
-    //if (debug_level >= 1) console.log("bounds:", bounds);
-
-    var xmin_of_tile = bounds.getWest();
-    var xmax_of_tile = bounds.getEast();
-    var ymin_of_tile = bounds.getSouth();
-    var ymax_of_tile = bounds.getNorth();
-    //if (debug_level >= 1) console.log("ymax_of_tile:", ymax_of_tile);
-
-    var resolution = this.options.resolution;
-
-    var raster_pixels_across = Math.ceil((xmax_of_tile - xmin_of_tile) / pixelWidth);
-    var raster_pixels_down = Math.ceil((ymax_of_tile - ymin_of_tile) / pixelHeight);
-    var number_of_rectangles_across = Math.min(resolution, raster_pixels_across);
-    var number_of_rectangles_down = Math.min(resolution, raster_pixels_down);
-
-    var height_of_rectangle_in_pixels = this._tile_height / number_of_rectangles_down;
-    var height_of_rectangle_in_pixels_int = Math.ceil(height_of_rectangle_in_pixels);
-    //if (debug_level >= 1) console.log("height_of_rectangle_in_pixels:", height_of_rectangle_in_pixels);
-    var width_of_rectangle_in_pixels = this._tile_width / number_of_rectangles_across;
-    var width_of_rectangle_in_pixels_int = Math.ceil(width_of_rectangle_in_pixels);
-    //if (debug_level >= 1) console.log("width_of_rectangle:", width_of_rectangle_in_pixels);
-
-    var height_of_rectangle_in_degrees = (ymax_of_tile - ymin_of_tile) / number_of_rectangles_down;
-    //if (debug_level >= 1) console.log("height_of_rectangle_in_degrees:", height_of_rectangle_in_degrees);
-    var width_of_rectangle_in_degrees = (xmax_of_tile - xmin_of_tile) / number_of_rectangles_across;
-    //if (debug_level >= 1) console.log("width_of_rectangle_in_degrees:", width_of_rectangle_in_degrees);
-
-    //if (debug_level >= 1) console.log("ymax of raster:", ymax);
-
-    var number_of_pixels_per_rectangle = this._tile_width / 8;
-
-    var map = this._map;
-    var tileSize = this.getTileSize();
-    var tileNwPoint = coords.scaleBy(tileSize);
-
-    // render asynchronously so tiles show up as they finish instead of all at once (which blocks the UI)
-    setTimeout(async function () {
-      var _this = this;
-
-      var min_x = Number.MAX_SAFE_INTEGER;
-      var max_x = 0;
-      var min_y = Number.MAX_SAFE_INTEGER;
-      var max_y = 0;
-
-      var samples_per_pixel = null;
-      var tile_values = [];
-      if (rasters) {
-        samples_per_pixel = rasters.length;
-        for (var samp_i = 0; samp_i < samples_per_pixel; samp_i++) {
-          tile_values.push([]);
+            /*
+                Caching the constant tile size, so we don't recalculate everytime we
+                create a new tile
+            */
+            var tileSize = this.getTileSize();
+            this._tile_height = tileSize.y;
+            this._tile_width = tileSize.x;
+        } catch (error) {
+            console.error("ERROR initializing GeoTIFFLayer", error);
         }
-      }
+    },
 
-      var push_value = function push_value(value_array, values) {
-        for (var val_i = 0; val_i < samples_per_pixel; val_i++) {
-          var value = no_data_value;
-          if (values) {
-            value = values[val_i];
-          }
-          value_array[val_i].push(value);
-        }
-      };
+    getRasters: async function getRasters(map, tileNwPoint, height_of_rectangle_in_pixels, width_of_rectangle_in_pixels, coords, pixelHeight, pixelWidth, number_of_rectangles_across, number_of_rectangles_down, ymax, xmin) {
+        // called if georaster was constructed from URL and we need to get
+        // data separately for each tile
+        // aka "COG mode"
 
-      for (var h = 0; h < number_of_rectangles_down; h++) {
-        var y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
-        var latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
-        var latWest = map.unproject(latWestPoint, coords.z);
-        var lat = latWest.lat;
-        //if (debug_level >= 2) console.log("lat:", lat);
-        if (!rasters || lat > ymin && lat < ymax) {
-          (function () {
+        var raster_coords_for_tile_coords = function raster_coords_for_tile_coords(h, w) {
+            var y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
+            var latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
+            var latWest = map.unproject(latWestPoint, coords.z);
+            var lat = latWest.lat;
             var y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
             var y_in_raster_pixels = Math.floor((ymax - lat) / pixelHeight);
-            for (var w = 0; w < number_of_rectangles_across; w++) {
-              var latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
-              var latLng = map.unproject(latLngPoint, coords.z);
-              var lng = latLng.lng;
-              //if (debug_level >= 2) console.log("lng:", lng);
-              if (!rasters || lng > xmin && lng < xmax) {
-                (function () {
-                  //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#00FF00"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
-                  var x_in_raster_pixels = Math.floor((lng - xmin) / pixelWidth);
 
-                  if (debug_level >= 1) time_started_reading_rasters = performance.now();
-                  if (rasters) {
-                    var values = rasters.map(function (raster) {
-                      return raster[y_in_raster_pixels][x_in_raster_pixels];
-                    });
-                    push_value(tile_values, values);
-                  } else {
-                    if (y_in_raster_pixels < min_y) {
-                      min_y = y_in_raster_pixels;
-                    }
-                    if (y_in_raster_pixels > max_y) {
-                      max_y = y_in_raster_pixels;
-                    }
-                    if (x_in_raster_pixels < min_x) {
-                      min_x = x_in_raster_pixels;
-                    }
-                    if (x_in_raster_pixels > max_x) {
-                      max_x = x_in_raster_pixels;
-                    }
-                  }
-                })();
-              } else {
-                if (rasters) {
-                  push_value(tile_values);
-                }
-              }
-            }
-          })();
-        } else {
-          if (rasters) {
-            for (var w = 0; w < number_of_rectangles_across; w++) {
-              push_value(tile_values);
-            }
-          }
-        }
-      }
-
-      if (!rasters) {
-        // careful not to flip min_y/max_y here
-        tile_values = await this.georaster.getValues(min_x, min_y, max_x, max_y, number_of_rectangles_across, number_of_rectangles_down);
-      }
-
-      var tile_values_2d = tile_values.map(function (valuesInOneDimension) {
-        var valuesInTwoDimensions = [];
-        var width = number_of_rectangles_across;
-        var height = number_of_rectangles_down;
-        for (var y = 0; y < height; y++) {
-          var start = y * width;
-          var end = start + width;
-          valuesInTwoDimensions.push(valuesInOneDimension.slice(start, end));
-        }
-        return valuesInTwoDimensions;
-      });
-
-      var _loop = function _loop(_h) {
-        var y_center_in_map_pixels = tileNwPoint.y + (_h + 0.5) * height_of_rectangle_in_pixels;
-        var latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
-        var latWest = map.unproject(latWestPoint, coords.z);
-        var lat = latWest.lat;
-        //if (debug_level >= 2) console.log("lat:", lat);
-        if (lat > ymin && lat < ymax) {
-          var y_in_tile_pixels = Math.round(_h * height_of_rectangle_in_pixels);
-          var y_in_raster_pixels = Math.floor((ymax - lat) / pixelHeight);
-
-          var _loop2 = function _loop2(_w) {
-            var latLngPoint = L.point(tileNwPoint.x + (_w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
+            var latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
             var latLng = map.unproject(latLngPoint, coords.z);
             var lng = latLng.lng;
-            //if (debug_level >= 2) console.log("lng:", lng);
-            if (lng > xmin && lng < xmax) {
-              //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#00FF00"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
-              var x_in_raster_pixels = Math.floor((lng - xmin) / pixelWidth);
+            var x_in_raster_pixels = Math.floor((lng - xmin) / pixelWidth);
 
-              if (debug_level >= 1) time_started_reading_rasters = performance.now();
-              var values = tile_values_2d.map(function (raster) {
-                return raster[_h][_w];
-              });
-              if (debug_level >= 1) duration_reading_rasters += performance.now() - time_started_reading_rasters;
-              var color = null;
-              if (_this.options.pixelValueToColorFn) {
-                color = _this.options.pixelValueToColorFn(values[0]);
-              } else {
-                var number_of_values = values.length;
-                if (number_of_values == 1) {
-                  var value = values[0];
-                  if (ranges) {
-                    if (value != no_data_value) {
-                      color = scale((values[0] - mins[0]) / ranges[0]).hex();
-                    }
-                  } else {
-                    // TODO not sure what to do here - For COG, we don't know the min max of the full raster.
-                    // Currently I'm just hardcoding to a value that works for the LS8 raster I'm looking at.
-                    color = scale((values[0] - 10798) / (16110 - 10798)).hex();
-                  }
-                } else if (number_of_values == 2) {} else if (number_of_values == 3) {
-                  if (values[0] != no_data_value) {
-                    color = "rgb(" + values[0] + "," + values[1] + "," + values[2] + ")";
-                  }
-                }
-              }
-              //let colors = ["red", "green", "blue", "pink", "purple", "orange"];
-              //let color = colors[Math.round(colors.length * Math.random())];
-              //context.fillStyle = this.getColor(color);
-              if (color) {
-                context.fillStyle = color;
-                if (debug_level >= 1) time_started_filling_rect = performance.now();
-                context.fillRect(Math.round(_w * width_of_rectangle_in_pixels), y_in_tile_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int);
-                if (debug_level >= 1) duration_filling_rects += performance.now() - time_started_filling_rect;
-              }
-              //if (debug_level >= 2) console.log("filling:", [w * width_of_rectangle_in_pixels, rect_y_in_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int]);
-              //if (debug_level >= 2) console.log("with color:", color);
-              //if (debug_level >= 2) console.log("with context:", context);
-            } else {
-                //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#FF0000"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
-              }
-          };
+            return [y_in_raster_pixels, x_in_raster_pixels];
+        };
 
-          for (var _w = 0; _w < number_of_rectangles_across; _w++) {
-            _loop2(_w);
-          }
+        var result = raster_coords_for_tile_coords(0, 0);
+        var min_y = result[0];
+        var min_x = result[1];
+        result = raster_coords_for_tile_coords(number_of_rectangles_down - 1, number_of_rectangles_across - 1);
+        var max_y = result[0];
+        var max_x = result[1];
+
+        // careful not to flip min_y/max_y here
+        var tile_values = await this.georaster.getValues(min_x, min_y, max_x, max_y, number_of_rectangles_across, number_of_rectangles_down);
+
+        var tile_values_2d = tile_values.map(function (valuesInOneDimension) {
+            var valuesInTwoDimensions = [];
+            var width = number_of_rectangles_across;
+            var height = number_of_rectangles_down;
+            for (var y = 0; y < height; y++) {
+                var start = y * width;
+                var end = start + width;
+                valuesInTwoDimensions.push(valuesInOneDimension.slice(start, end));
+            }
+            return valuesInTwoDimensions;
+        });
+
+        return tile_values_2d;
+    },
+
+    createTile: function createTile(coords, done) {
+
+        var error;
+
+        var debug_level = 0;
+
+        if (debug_level >= 1) {
+            var start_time = performance.now();
+            var duration_reading_rasters = 0;
+            var time_started_reading_rasters;
+            var time_started_filling_rect;
+            var duration_filling_rects = 0;
         }
-      };
 
-      for (var _h = 0; _h < number_of_rectangles_down; _h++) {
-        _loop(_h);
-      }
+        /*
+            Unpacking values for use later.
+            We do this in order to increase speed.
+        */
+        var maxs = this._maxs;
+        var mins = this._mins;
+        var ranges = this._ranges;
+        var no_data_value = this._no_data_value;
+        var pixelWidth = this._pixelWidth;
+        var pixelHeight = this._pixelHeight;
+        var rasters = this._rasters;
+        var scale = this.scale;
+        var tiff_width = this._tiff_width;
+        var xmin = this._xmin;
+        var ymin = this._ymin;
+        var xmax = this._xmax;
+        var ymax = this._ymax;
 
-      if (debug_level >= 1) {
-        var duration = performance.now() - start_time;
-        console.log("creating tile took ", duration, "milliseconds");
-        console.log("took", duration_reading_rasters, "milliseconds to read rasters, which is ", Math.round(duration_reading_rasters / duration * 100), "percentage of the total time");
-        console.log("took", duration_filling_rects, "milliseconds to fill rects, which is ", Math.round(duration_filling_rects / duration * 100), "percentage of the total time");
-      }
-      //if (debug_level >= 1) console.groupEnd();
+        //if (debug_level >= 1) console.group();
 
-      done(error, tile);
-    }.bind(this), 0);
+        //if (debug_level >= 1) console.log("starting createTile with coords:", coords);
 
-    // return the tile so it can be rendered on screen
-    return tile;
-  },
 
-  // method from https://github.com/Leaflet/Leaflet/blob/bb1d94ac7f2716852213dd11563d89855f8d6bb1/src/layer/ImageOverlay.js
-  getBounds: function getBounds() {
-    return this._bounds;
-  },
+        // create a <canvas> element for drawing
+        var tile = L.DomUtil.create('canvas', 'leaflet-tile');
+        tile.height = this._tile_height;
+        tile.width = this._tile_width;
 
-  getColor: function getColor(name) {
-    var d = document.createElement("div");
-    d.style.color = name;
-    document.body.appendChild(d);
-    return window.getComputedStyle(d).color;
-  }
+        // get a canvas context and draw something on it using coords.x, coords.y and coords.z
+        var context = tile.getContext('2d');
+
+        var bounds = this._tileCoordsToBounds(coords);
+        //if (debug_level >= 1) console.log("bounds:", bounds);
+
+        var xmin_of_tile = bounds.getWest();
+        var xmax_of_tile = bounds.getEast();
+        var ymin_of_tile = bounds.getSouth();
+        var ymax_of_tile = bounds.getNorth();
+        //if (debug_level >= 1) console.log("ymax_of_tile:", ymax_of_tile);
+
+        var resolution = this.options.resolution;
+
+        var raster_pixels_across = Math.ceil((xmax_of_tile - xmin_of_tile) / pixelWidth);
+        var raster_pixels_down = Math.ceil((ymax_of_tile - ymin_of_tile) / pixelHeight);
+        var number_of_rectangles_across = Math.min(resolution, raster_pixels_across);
+        var number_of_rectangles_down = Math.min(resolution, raster_pixels_down);
+
+        var height_of_rectangle_in_pixels = this._tile_height / number_of_rectangles_down;
+        var height_of_rectangle_in_pixels_int = Math.ceil(height_of_rectangle_in_pixels);
+        //if (debug_level >= 1) console.log("height_of_rectangle_in_pixels:", height_of_rectangle_in_pixels);
+        var width_of_rectangle_in_pixels = this._tile_width / number_of_rectangles_across;
+        var width_of_rectangle_in_pixels_int = Math.ceil(width_of_rectangle_in_pixels);
+        //if (debug_level >= 1) console.log("width_of_rectangle:", width_of_rectangle_in_pixels);
+
+        var height_of_rectangle_in_degrees = (ymax_of_tile - ymin_of_tile) / number_of_rectangles_down;
+        //if (debug_level >= 1) console.log("height_of_rectangle_in_degrees:", height_of_rectangle_in_degrees);
+        var width_of_rectangle_in_degrees = (xmax_of_tile - xmin_of_tile) / number_of_rectangles_across;
+        //if (debug_level >= 1) console.log("width_of_rectangle_in_degrees:", width_of_rectangle_in_degrees);
+
+        //if (debug_level >= 1) console.log("ymax of raster:", ymax);
+
+        var number_of_pixels_per_rectangle = this._tile_width / 8;
+
+        var map = this._map;
+        var tileSize = this.getTileSize();
+        var tileNwPoint = coords.scaleBy(tileSize);
+
+        // render asynchronously so tiles show up as they finish instead of all at once (which blocks the UI)
+        setTimeout(async function () {
+            var _this = this;
+
+            var tile_rasters = null;
+            if (!rasters) {
+                tile_rasters = await this.getRasters(map, tileNwPoint, height_of_rectangle_in_pixels, width_of_rectangle_in_pixels, coords, pixelHeight, pixelWidth, number_of_rectangles_across, number_of_rectangles_down, ymax, xmin);
+            }
+
+            var _loop = function _loop(h) {
+                var y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
+                var latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
+                var latWest = map.unproject(latWestPoint, coords.z);
+                var lat = latWest.lat;
+                //if (debug_level >= 2) console.log("lat:", lat);
+                if (lat > ymin && lat < ymax) {
+                    (function () {
+                        var y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
+                        var y_in_raster_pixels = Math.floor((ymax - lat) / pixelHeight);
+
+                        var _loop2 = function _loop2(w) {
+                            var latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
+                            var latLng = map.unproject(latLngPoint, coords.z);
+                            var lng = latLng.lng;
+                            //if (debug_level >= 2) console.log("lng:", lng);
+                            if (lng > xmin && lng < xmax) {
+                                //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#00FF00"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
+                                var x_in_raster_pixels = Math.floor((lng - xmin) / pixelWidth);
+
+                                if (debug_level >= 1) time_started_reading_rasters = performance.now();
+                                var values = null;
+                                if (tile_rasters) {
+                                    // get value from array specific to this tile
+                                    values = tile_rasters.map(function (raster) {
+                                        return raster[h][w];
+                                    });
+                                } else {
+                                    // get value from array with data for entire raster
+                                    values = rasters.map(function (raster) {
+                                        return raster[y_in_raster_pixels][x_in_raster_pixels];
+                                    });
+                                }
+                                if (debug_level >= 1) duration_reading_rasters += performance.now() - time_started_reading_rasters;
+
+                                var color = null;
+                                if (_this.options.pixelValueToColorFn) {
+                                    color = _this.options.pixelValueToColorFn(values[0]);
+                                } else {
+                                    var number_of_values = values.length;
+                                    if (number_of_values == 1) {
+                                        var value = values[0];
+                                        if (ranges) {
+                                            if (value != no_data_value) {
+                                                color = scale((values[0] - mins[0]) / ranges[0]).hex();
+                                            }
+                                        } else {
+                                            // TODO not sure what to do here - For COG, we don't know the min max of the full raster.
+                                            // Currently I'm just hardcoding to a value that works for the LS8 raster I'm looking at.
+                                            color = scale((values[0] - 10798) / (16110 - 10798)).hex();
+                                        }
+                                    } else if (number_of_values == 2) {} else if (number_of_values == 3) {
+                                        if (values[0] != no_data_value) {
+                                            color = "rgb(" + values[0] + "," + values[1] + "," + values[2] + ")";
+                                        }
+                                    }
+                                }
+                                //let colors = ["red", "green", "blue", "pink", "purple", "orange"];
+                                //let color = colors[Math.round(colors.length * Math.random())];
+                                //context.fillStyle = this.getColor(color);
+                                if (color) {
+                                    context.fillStyle = color;
+                                    if (debug_level >= 1) time_started_filling_rect = performance.now();
+                                    context.fillRect(Math.round(w * width_of_rectangle_in_pixels), y_in_tile_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int);
+                                    if (debug_level >= 1) duration_filling_rects += performance.now() - time_started_filling_rect;
+                                }
+                                //if (debug_level >= 2) console.log("filling:", [w * width_of_rectangle_in_pixels, rect_y_in_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int]);
+                                //if (debug_level >= 2) console.log("with color:", color);
+                                //if (debug_level >= 2) console.log("with context:", context);
+                            } else {
+                                    //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#FF0000"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
+                                }
+                        };
+
+                        for (var w = 0; w < number_of_rectangles_across; w++) {
+                            _loop2(w);
+                        }
+                    })();
+                }
+            };
+
+            for (var h = 0; h < number_of_rectangles_down; h++) {
+                _loop(h);
+            }
+
+            if (debug_level >= 1) {
+                var duration = performance.now() - start_time;
+                console.log("creating tile took ", duration, "milliseconds");
+                console.log("took", duration_reading_rasters, "milliseconds to read rasters, which is ", Math.round(duration_reading_rasters / duration * 100), "percentage of the total time");
+                console.log("took", duration_filling_rects, "milliseconds to fill rects, which is ", Math.round(duration_filling_rects / duration * 100), "percentage of the total time");
+            }
+            //if (debug_level >= 1) console.groupEnd();
+
+            done(error, tile);
+        }.bind(this), 0);
+
+        // return the tile so it can be rendered on screen
+        return tile;
+    },
+
+    // method from https://github.com/Leaflet/Leaflet/blob/bb1d94ac7f2716852213dd11563d89855f8d6bb1/src/layer/ImageOverlay.js
+    getBounds: function getBounds() {
+        return this._bounds;
+    },
+
+    getColor: function getColor(name) {
+        var d = document.createElement("div");
+        d.style.color = name;
+        document.body.appendChild(d);
+        return window.getComputedStyle(d).color;
+    }
 });
 
 if (typeof module !== "undefined" && typeof module.exports !== "undefined") {
-  module.exports = GeoRasterLayer;
+    module.exports = GeoRasterLayer;
 }
 if (typeof window !== "undefined") {
-  window["GeoRasterLayer"] = GeoRasterLayer;
+    window["GeoRasterLayer"] = GeoRasterLayer;
 } else if (typeof self !== "undefined") {
-  self["GeoRasterLayer"] = GeoRasterLayer; // jshint ignore:line
+    self["GeoRasterLayer"] = GeoRasterLayer; // jshint ignore:line
 }

--- a/georaster-layer-for-leaflet.bundle.js
+++ b/georaster-layer-for-leaflet.bundle.js
@@ -38,6 +38,12 @@ var GeoRasterLayer = L.GridLayer.extend({
             this._xmax = georaster.xmax;
             this._ymax = georaster.ymax;
 
+            if (georaster.sourceType === 'url' && georaster.numberOfRasters === 1 && !options.pixelValueToColorFn) {
+                // For COG, we can't determine a data min max for color scaling,
+                // so pixelValueToColorFn is required.
+                throw "pixelValueToColorFn is a required option for single-band rasters initialized via URL";
+            }
+
             console.log("georaster.ymin:", georaster.ymin);
             var southWest = L.latLng(georaster.ymin, georaster.xmin);
             var northEast = L.latLng(georaster.ymax, georaster.xmax);
@@ -236,14 +242,8 @@ var GeoRasterLayer = L.GridLayer.extend({
                                     var number_of_values = values.length;
                                     if (number_of_values == 1) {
                                         var value = values[0];
-                                        if (ranges) {
-                                            if (value != no_data_value) {
-                                                color = scale((values[0] - mins[0]) / ranges[0]).hex();
-                                            }
-                                        } else {
-                                            // TODO not sure what to do here - For COG, we don't know the min max of the full raster.
-                                            // Currently I'm just hardcoding to a value that works for the LS8 raster I'm looking at.
-                                            color = scale((values[0] - 10798) / (16110 - 10798)).hex();
+                                        if (value != no_data_value) {
+                                            color = scale((values[0] - mins[0]) / ranges[0]).hex();
                                         }
                                     } else if (number_of_values == 2) {} else if (number_of_values == 3) {
                                         if (values[0] != no_data_value) {

--- a/georaster-layer-for-leaflet.bundle.js
+++ b/georaster-layer-for-leaflet.bundle.js
@@ -6,230 +6,348 @@ var L = window.L;
 
 var GeoRasterLayer = L.GridLayer.extend({
 
-    initialize: function initialize(options) {
-        try {
-            console.log("starting GeoRasterLayer.initialize with", options);
+  initialize: function initialize(options) {
+    try {
+      console.log("starting GeoRasterLayer.initialize with", options);
 
-            if (!options.keepBuffer) options.keepBuffer = 25;
+      if (!options.keepBuffer) options.keepBuffer = 25;
 
-            if (!options.resolution) options.resolution = Math.pow(2, 5);
+      if (!options.resolution) options.resolution = Math.pow(2, 5);
 
-            if (options.updateWhenZooming === undefined) options.updateWhenZooming = false;
+      if (options.updateWhenZooming === undefined) options.updateWhenZooming = false;
 
-            var georaster = options.georaster;
-            this.georaster = georaster;
+      var georaster = options.georaster;
+      this.georaster = georaster;
 
-            this.scale = chroma.scale();
+      this.scale = chroma.scale();
 
-            /*
-                Unpacking values for use later.
-                We do this in order to increase speed.
-            */
-            this._maxs = georaster.maxs;
-            this._mins = georaster.mins;
-            this._ranges = georaster.ranges;
-            this._no_data_value = georaster.noDataValue;
-            this._pixelWidth = georaster.pixelWidth;
-            this._pixelHeight = georaster.pixelHeight;
-            this._rasters = georaster.values;
-            this._tiff_width = georaster.width;
-            this._xmin = georaster.xmin;
-            this._ymin = georaster.ymin;
-            this._xmax = georaster.xmax;
-            this._ymax = georaster.ymax;
+      /*
+          Unpacking values for use later.
+          We do this in order to increase speed.
+      */
+      this._maxs = georaster.maxs;
+      this._mins = georaster.mins;
+      this._ranges = georaster.ranges;
+      this._no_data_value = georaster.noDataValue;
+      this._pixelWidth = georaster.pixelWidth;
+      this._pixelHeight = georaster.pixelHeight;
+      this._rasters = georaster.values;
+      this._tiff_width = georaster.width;
+      this._xmin = georaster.xmin;
+      this._ymin = georaster.ymin;
+      this._xmax = georaster.xmax;
+      this._ymax = georaster.ymax;
 
-            console.log("georaster.ymin:", georaster.ymin);
-            var southWest = L.latLng(georaster.ymin, georaster.xmin);
-            var northEast = L.latLng(georaster.ymax, georaster.xmax);
-            this._bounds = L.latLngBounds(southWest, northEast);
-            console.log("this._bounds:", this._bounds);
-            options.bounds = this._bounds;
-            L.setOptions(this, options);
+      console.log("georaster.ymin:", georaster.ymin);
+      var southWest = L.latLng(georaster.ymin, georaster.xmin);
+      var northEast = L.latLng(georaster.ymax, georaster.xmax);
+      this._bounds = L.latLngBounds(southWest, northEast);
+      console.log("this._bounds:", this._bounds);
+      options.bounds = this._bounds;
+      L.setOptions(this, options);
 
-            /*
-                Caching the constant tile size, so we don't recalculate everytime we
-                create a new tile
-            */
-            var tileSize = this.getTileSize();
-            this._tile_height = tileSize.y;
-            this._tile_width = tileSize.x;
-        } catch (error) {
-            console.error("ERROR initializing GeoTIFFLayer", error);
-        }
-    },
-
-    createTile: function createTile(coords) {
-        var _this = this;
-
-        var debug_level = 0;
-
-        if (debug_level >= 1) {
-            var start_time = performance.now();
-            var duration_reading_rasters = 0;
-            var time_started_reading_rasters;
-            var time_started_filling_rect;
-            var duration_filling_rects = 0;
-        }
-
-        /*
-            Unpacking values for use later.
-            We do this in order to increase speed.
-        */
-        var maxs = this._maxs;
-        var mins = this._mins;
-        var ranges = this._ranges;
-        var no_data_value = this._no_data_value;
-        var pixelWidth = this._pixelWidth;
-        var pixelHeight = this._pixelHeight;
-        var rasters = this._rasters;
-        var scale = this.scale;
-        var tiff_width = this._tiff_width;
-        var xmin = this._xmin;
-        var ymin = this._ymin;
-        var xmax = this._xmax;
-        var ymax = this._ymax;
-
-        //if (debug_level >= 1) console.group();
-
-        //if (debug_level >= 1) console.log("starting createTile with coords:", coords);
-
-
-        // create a <canvas> element for drawing
-        var tile = L.DomUtil.create('canvas', 'leaflet-tile');
-        tile.height = this._tile_height;
-        tile.width = this._tile_width;
-
-        // get a canvas context and draw something on it using coords.x, coords.y and coords.z
-        var context = tile.getContext('2d');
-
-        var bounds = this._tileCoordsToBounds(coords);
-        //if (debug_level >= 1) console.log("bounds:", bounds);
-
-        var xmin_of_tile = bounds.getWest();
-        var xmax_of_tile = bounds.getEast();
-        var ymin_of_tile = bounds.getSouth();
-        var ymax_of_tile = bounds.getNorth();
-        //if (debug_level >= 1) console.log("ymax_of_tile:", ymax_of_tile);
-
-        var resolution = this.options.resolution;
-
-        var raster_pixels_across = Math.ceil((xmax_of_tile - xmin_of_tile) / pixelWidth);
-        var raster_pixels_down = Math.ceil((ymax_of_tile - ymin_of_tile) / pixelHeight);
-        var number_of_rectangles_across = Math.min(resolution, raster_pixels_across);
-        var number_of_rectangles_down = Math.min(resolution, raster_pixels_down);
-
-        var height_of_rectangle_in_pixels = this._tile_height / number_of_rectangles_down;
-        var height_of_rectangle_in_pixels_int = Math.ceil(height_of_rectangle_in_pixels);
-        //if (debug_level >= 1) console.log("height_of_rectangle_in_pixels:", height_of_rectangle_in_pixels);
-        var width_of_rectangle_in_pixels = this._tile_width / number_of_rectangles_across;
-        var width_of_rectangle_in_pixels_int = Math.ceil(width_of_rectangle_in_pixels);
-        //if (debug_level >= 1) console.log("width_of_rectangle:", width_of_rectangle_in_pixels);
-
-        var height_of_rectangle_in_degrees = (ymax_of_tile - ymin_of_tile) / number_of_rectangles_down;
-        //if (debug_level >= 1) console.log("height_of_rectangle_in_degrees:", height_of_rectangle_in_degrees);
-        var width_of_rectangle_in_degrees = (xmax_of_tile - xmin_of_tile) / number_of_rectangles_across;
-        //if (debug_level >= 1) console.log("width_of_rectangle_in_degrees:", width_of_rectangle_in_degrees);
-
-        //if (debug_level >= 1) console.log("ymax of raster:", ymax);
-
-        var number_of_pixels_per_rectangle = this._tile_width / 8;
-
-        var map = this._map;
-        var tileSize = this.getTileSize();
-        var tileNwPoint = coords.scaleBy(tileSize);
-
-        for (var h = 0; h < number_of_rectangles_down; h++) {
-            var y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
-            var latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
-            var latWest = map.unproject(latWestPoint, coords.z);
-            var lat = latWest.lat;
-            //if (debug_level >= 2) console.log("lat:", lat);
-            if (lat > ymin && lat < ymax) {
-                (function () {
-                    var y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
-                    var y_in_raster_pixels = Math.floor((ymax - lat) / pixelHeight);
-                    for (var w = 0; w < number_of_rectangles_across; w++) {
-                        var latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
-                        var latLng = map.unproject(latLngPoint, coords.z);
-                        var lng = latLng.lng;
-                        //if (debug_level >= 2) console.log("lng:", lng);
-                        if (lng > xmin && lng < xmax) {
-                            (function () {
-                                //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#00FF00"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
-                                var x_in_raster_pixels = Math.floor((lng - xmin) / pixelWidth);
-
-                                if (debug_level >= 1) time_started_reading_rasters = performance.now();
-                                var values = rasters.map(function (raster) {
-                                    return raster[y_in_raster_pixels][x_in_raster_pixels];
-                                });
-                                if (debug_level >= 1) duration_reading_rasters += performance.now() - time_started_reading_rasters;
-                                var color = null;
-                                if (_this.options.pixelValueToColorFn) {
-                                    color = _this.options.pixelValueToColorFn(values[0]);
-                                } else {
-                                    var number_of_values = values.length;
-                                    if (number_of_values == 1) {
-                                        var value = values[0];
-                                        if (value != no_data_value) {
-                                            color = scale((values[0] - mins[0]) / ranges[0]).hex();
-                                        }
-                                    } else if (number_of_values == 2) {} else if (number_of_values == 3) {
-                                        if (values[0] != no_data_value) {
-                                            color = "rgb(" + values[0] + "," + values[1] + "," + values[2] + ")";
-                                        }
-                                    }
-                                }
-                                //let colors = ["red", "green", "blue", "pink", "purple", "orange"];
-                                //let color = colors[Math.round(colors.length * Math.random())];
-                                //context.fillStyle = this.getColor(color);
-                                if (color) {
-                                    context.fillStyle = color;
-                                    if (debug_level >= 1) time_started_filling_rect = performance.now();
-                                    context.fillRect(Math.round(w * width_of_rectangle_in_pixels), y_in_tile_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int);
-                                    if (debug_level >= 1) duration_filling_rects += performance.now() - time_started_filling_rect;
-                                }
-                                //if (debug_level >= 2) console.log("filling:", [w * width_of_rectangle_in_pixels, rect_y_in_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int]);
-                                //if (debug_level >= 2) console.log("with color:", color);
-                                //if (debug_level >= 2) console.log("with context:", context);
-                            })();
-                        } else {
-                                //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#FF0000"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
-                            }
-                    }
-                })();
-            }
-        }
-
-        if (debug_level >= 1) {
-            var duration = performance.now() - start_time;
-            console.log("creating tile took ", duration, "milliseconds");
-            console.log("took", duration_reading_rasters, "milliseconds to read rasters, which is ", Math.round(duration_reading_rasters / duration * 100), "percentage of the total time");
-            console.log("took", duration_filling_rects, "milliseconds to fill rects, which is ", Math.round(duration_filling_rects / duration * 100), "percentage of the total time");
-        }
-        //if (debug_level >= 1) console.groupEnd();
-
-        // return the tile so it can be rendered on screen
-        return tile;
-    },
-
-    // method from https://github.com/Leaflet/Leaflet/blob/bb1d94ac7f2716852213dd11563d89855f8d6bb1/src/layer/ImageOverlay.js
-    getBounds: function getBounds() {
-        return this._bounds;
-    },
-
-    getColor: function getColor(name) {
-        var d = document.createElement("div");
-        d.style.color = name;
-        document.body.appendChild(d);
-        return window.getComputedStyle(d).color;
+      /*
+          Caching the constant tile size, so we don't recalculate everytime we
+          create a new tile
+      */
+      var tileSize = this.getTileSize();
+      this._tile_height = tileSize.y;
+      this._tile_width = tileSize.x;
+    } catch (error) {
+      console.error("ERROR initializing GeoTIFFLayer", error);
     }
+  },
+
+  createTile: function createTile(coords, done) {
+    // createTile: function(coords) {
+
+    var error;
+
+    var debug_level = 0;
+
+    if (debug_level >= 1) {
+      var start_time = performance.now();
+      var duration_reading_rasters = 0;
+      var time_started_reading_rasters;
+      var time_started_filling_rect;
+      var duration_filling_rects = 0;
+    }
+
+    /*
+        Unpacking values for use later.
+        We do this in order to increase speed.
+    */
+    var maxs = this._maxs;
+    var mins = this._mins;
+    var ranges = this._ranges;
+    var no_data_value = this._no_data_value;
+    var pixelWidth = this._pixelWidth;
+    var pixelHeight = this._pixelHeight;
+    var rasters = this._rasters;
+    var scale = this.scale;
+    var tiff_width = this._tiff_width;
+    var xmin = this._xmin;
+    var ymin = this._ymin;
+    var xmax = this._xmax;
+    var ymax = this._ymax;
+
+    //if (debug_level >= 1) console.group();
+
+    //if (debug_level >= 1) console.log("starting createTile with coords:", coords);
+
+
+    // create a <canvas> element for drawing
+    var tile = L.DomUtil.create('canvas', 'leaflet-tile');
+    tile.height = this._tile_height;
+    tile.width = this._tile_width;
+
+    // get a canvas context and draw something on it using coords.x, coords.y and coords.z
+    var context = tile.getContext('2d');
+
+    var bounds = this._tileCoordsToBounds(coords);
+    //if (debug_level >= 1) console.log("bounds:", bounds);
+
+    var xmin_of_tile = bounds.getWest();
+    var xmax_of_tile = bounds.getEast();
+    var ymin_of_tile = bounds.getSouth();
+    var ymax_of_tile = bounds.getNorth();
+    //if (debug_level >= 1) console.log("ymax_of_tile:", ymax_of_tile);
+
+    var resolution = this.options.resolution;
+
+    var raster_pixels_across = Math.ceil((xmax_of_tile - xmin_of_tile) / pixelWidth);
+    var raster_pixels_down = Math.ceil((ymax_of_tile - ymin_of_tile) / pixelHeight);
+    var number_of_rectangles_across = Math.min(resolution, raster_pixels_across);
+    var number_of_rectangles_down = Math.min(resolution, raster_pixels_down);
+
+    var height_of_rectangle_in_pixels = this._tile_height / number_of_rectangles_down;
+    var height_of_rectangle_in_pixels_int = Math.ceil(height_of_rectangle_in_pixels);
+    //if (debug_level >= 1) console.log("height_of_rectangle_in_pixels:", height_of_rectangle_in_pixels);
+    var width_of_rectangle_in_pixels = this._tile_width / number_of_rectangles_across;
+    var width_of_rectangle_in_pixels_int = Math.ceil(width_of_rectangle_in_pixels);
+    //if (debug_level >= 1) console.log("width_of_rectangle:", width_of_rectangle_in_pixels);
+
+    var height_of_rectangle_in_degrees = (ymax_of_tile - ymin_of_tile) / number_of_rectangles_down;
+    //if (debug_level >= 1) console.log("height_of_rectangle_in_degrees:", height_of_rectangle_in_degrees);
+    var width_of_rectangle_in_degrees = (xmax_of_tile - xmin_of_tile) / number_of_rectangles_across;
+    //if (debug_level >= 1) console.log("width_of_rectangle_in_degrees:", width_of_rectangle_in_degrees);
+
+    //if (debug_level >= 1) console.log("ymax of raster:", ymax);
+
+    var number_of_pixels_per_rectangle = this._tile_width / 8;
+
+    var map = this._map;
+    var tileSize = this.getTileSize();
+    var tileNwPoint = coords.scaleBy(tileSize);
+
+    // render asynchronously so tiles show up as they finish instead of all at once (which blocks the UI)
+    setTimeout(async function () {
+      var _this = this;
+
+      var min_x = Number.MAX_SAFE_INTEGER;
+      var max_x = 0;
+      var min_y = Number.MAX_SAFE_INTEGER;
+      var max_y = 0;
+
+      var samples_per_pixel = null;
+      var tile_values = [];
+      if (rasters) {
+        samples_per_pixel = rasters.length;
+        for (var samp_i = 0; samp_i < samples_per_pixel; samp_i++) {
+          tile_values.push([]);
+        }
+      }
+
+      var push_value = function push_value(value_array, values) {
+        for (var val_i = 0; val_i < samples_per_pixel; val_i++) {
+          var value = no_data_value;
+          if (values) {
+            value = values[val_i];
+          }
+          value_array[val_i].push(value);
+        }
+      };
+
+      for (var h = 0; h < number_of_rectangles_down; h++) {
+        var y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
+        var latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
+        var latWest = map.unproject(latWestPoint, coords.z);
+        var lat = latWest.lat;
+        //if (debug_level >= 2) console.log("lat:", lat);
+        if (!rasters || lat > ymin && lat < ymax) {
+          (function () {
+            var y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
+            var y_in_raster_pixels = Math.floor((ymax - lat) / pixelHeight);
+            for (var w = 0; w < number_of_rectangles_across; w++) {
+              var latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
+              var latLng = map.unproject(latLngPoint, coords.z);
+              var lng = latLng.lng;
+              //if (debug_level >= 2) console.log("lng:", lng);
+              if (!rasters || lng > xmin && lng < xmax) {
+                (function () {
+                  //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#00FF00"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
+                  var x_in_raster_pixels = Math.floor((lng - xmin) / pixelWidth);
+
+                  if (debug_level >= 1) time_started_reading_rasters = performance.now();
+                  if (rasters) {
+                    var values = rasters.map(function (raster) {
+                      return raster[y_in_raster_pixels][x_in_raster_pixels];
+                    });
+                    push_value(tile_values, values);
+                  } else {
+                    if (y_in_raster_pixels < min_y) {
+                      min_y = y_in_raster_pixels;
+                    }
+                    if (y_in_raster_pixels > max_y) {
+                      max_y = y_in_raster_pixels;
+                    }
+                    if (x_in_raster_pixels < min_x) {
+                      min_x = x_in_raster_pixels;
+                    }
+                    if (x_in_raster_pixels > max_x) {
+                      max_x = x_in_raster_pixels;
+                    }
+                  }
+                })();
+              } else {
+                if (rasters) {
+                  push_value(tile_values);
+                }
+              }
+            }
+          })();
+        } else {
+          if (rasters) {
+            for (var w = 0; w < number_of_rectangles_across; w++) {
+              push_value(tile_values);
+            }
+          }
+        }
+      }
+
+      if (!rasters) {
+        // careful not to flip min_y/max_y here
+        tile_values = await this.georaster.getValues(min_x, min_y, max_x, max_y, number_of_rectangles_across, number_of_rectangles_down);
+      }
+
+      var tile_values_2d = tile_values.map(function (valuesInOneDimension) {
+        var valuesInTwoDimensions = [];
+        var width = number_of_rectangles_across;
+        var height = number_of_rectangles_down;
+        for (var y = 0; y < height; y++) {
+          var start = y * width;
+          var end = start + width;
+          valuesInTwoDimensions.push(valuesInOneDimension.slice(start, end));
+        }
+        return valuesInTwoDimensions;
+      });
+
+      var _loop = function _loop(_h) {
+        var y_center_in_map_pixels = tileNwPoint.y + (_h + 0.5) * height_of_rectangle_in_pixels;
+        var latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
+        var latWest = map.unproject(latWestPoint, coords.z);
+        var lat = latWest.lat;
+        //if (debug_level >= 2) console.log("lat:", lat);
+        if (lat > ymin && lat < ymax) {
+          var y_in_tile_pixels = Math.round(_h * height_of_rectangle_in_pixels);
+          var y_in_raster_pixels = Math.floor((ymax - lat) / pixelHeight);
+
+          var _loop2 = function _loop2(_w) {
+            var latLngPoint = L.point(tileNwPoint.x + (_w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
+            var latLng = map.unproject(latLngPoint, coords.z);
+            var lng = latLng.lng;
+            //if (debug_level >= 2) console.log("lng:", lng);
+            if (lng > xmin && lng < xmax) {
+              //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#00FF00"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
+              var x_in_raster_pixels = Math.floor((lng - xmin) / pixelWidth);
+
+              if (debug_level >= 1) time_started_reading_rasters = performance.now();
+              var values = tile_values_2d.map(function (raster) {
+                return raster[_h][_w];
+              });
+              if (debug_level >= 1) duration_reading_rasters += performance.now() - time_started_reading_rasters;
+              var color = null;
+              if (_this.options.pixelValueToColorFn) {
+                color = _this.options.pixelValueToColorFn(values[0]);
+              } else {
+                var number_of_values = values.length;
+                if (number_of_values == 1) {
+                  var value = values[0];
+                  if (ranges) {
+                    if (value != no_data_value) {
+                      color = scale((values[0] - mins[0]) / ranges[0]).hex();
+                    }
+                  } else {
+                    // TODO not sure what to do here - For COG, we don't know the min max of the full raster.
+                    // Currently I'm just hardcoding to a value that works for the LS8 raster I'm looking at.
+                    color = scale((values[0] - 10798) / (16110 - 10798)).hex();
+                  }
+                } else if (number_of_values == 2) {} else if (number_of_values == 3) {
+                  if (values[0] != no_data_value) {
+                    color = "rgb(" + values[0] + "," + values[1] + "," + values[2] + ")";
+                  }
+                }
+              }
+              //let colors = ["red", "green", "blue", "pink", "purple", "orange"];
+              //let color = colors[Math.round(colors.length * Math.random())];
+              //context.fillStyle = this.getColor(color);
+              if (color) {
+                context.fillStyle = color;
+                if (debug_level >= 1) time_started_filling_rect = performance.now();
+                context.fillRect(Math.round(_w * width_of_rectangle_in_pixels), y_in_tile_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int);
+                if (debug_level >= 1) duration_filling_rects += performance.now() - time_started_filling_rect;
+              }
+              //if (debug_level >= 2) console.log("filling:", [w * width_of_rectangle_in_pixels, rect_y_in_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int]);
+              //if (debug_level >= 2) console.log("with color:", color);
+              //if (debug_level >= 2) console.log("with context:", context);
+            } else {
+                //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#FF0000"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
+              }
+          };
+
+          for (var _w = 0; _w < number_of_rectangles_across; _w++) {
+            _loop2(_w);
+          }
+        }
+      };
+
+      for (var _h = 0; _h < number_of_rectangles_down; _h++) {
+        _loop(_h);
+      }
+
+      if (debug_level >= 1) {
+        var duration = performance.now() - start_time;
+        console.log("creating tile took ", duration, "milliseconds");
+        console.log("took", duration_reading_rasters, "milliseconds to read rasters, which is ", Math.round(duration_reading_rasters / duration * 100), "percentage of the total time");
+        console.log("took", duration_filling_rects, "milliseconds to fill rects, which is ", Math.round(duration_filling_rects / duration * 100), "percentage of the total time");
+      }
+      //if (debug_level >= 1) console.groupEnd();
+
+      done(error, tile);
+    }.bind(this), 0);
+
+    // return the tile so it can be rendered on screen
+    return tile;
+  },
+
+  // method from https://github.com/Leaflet/Leaflet/blob/bb1d94ac7f2716852213dd11563d89855f8d6bb1/src/layer/ImageOverlay.js
+  getBounds: function getBounds() {
+    return this._bounds;
+  },
+
+  getColor: function getColor(name) {
+    var d = document.createElement("div");
+    d.style.color = name;
+    document.body.appendChild(d);
+    return window.getComputedStyle(d).color;
+  }
 });
 
 if (typeof module !== "undefined" && typeof module.exports !== "undefined") {
-    module.exports = GeoRasterLayer;
+  module.exports = GeoRasterLayer;
 }
 if (typeof window !== "undefined") {
-    window["GeoRasterLayer"] = GeoRasterLayer;
+  window["GeoRasterLayer"] = GeoRasterLayer;
 } else if (typeof self !== "undefined") {
-    self["GeoRasterLayer"] = GeoRasterLayer; // jshint ignore:line
+  self["GeoRasterLayer"] = GeoRasterLayer; // jshint ignore:line
 }

--- a/georaster-layer-for-leaflet.js
+++ b/georaster-layer-for-leaflet.js
@@ -17,7 +17,8 @@ var GeoRasterLayer = L.GridLayer.extend({
             let georaster = options.georaster;
             this.georaster = georaster;
 
-            this.scale = chroma.scale();
+            this.scale = chroma.scale(['black', 'white']);
+            // this.scale = chroma.scale();
 
             /*
                 Unpacking values for use later.
@@ -57,9 +58,13 @@ var GeoRasterLayer = L.GridLayer.extend({
         }
     },
 
-    createTile: function(coords) {
+    createTile: function(coords, done) {
+    // createTile: function(coords) {
 
-        let debug_level = 0;
+        var error;
+
+        console.log('createTile: ', coords);
+        let debug_level = 2;
 
         if (debug_level >= 1) {
             var start_time = performance.now();
@@ -138,71 +143,81 @@ var GeoRasterLayer = L.GridLayer.extend({
         let tileSize = this.getTileSize();
         let tileNwPoint = coords.scaleBy(tileSize);
 
-        for (let h = 0; h < number_of_rectangles_down; h++) {
-            let y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
-            let latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
-            let latWest = map.unproject(latWestPoint, coords.z);
-            let lat = latWest.lat;
-            //if (debug_level >= 2) console.log("lat:", lat);
-            if (lat > ymin && lat < ymax) {
-              let y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
-              let y_in_raster_pixels = Math.floor( (ymax - lat) / pixelHeight );
-              for (let w = 0; w < number_of_rectangles_across; w++) {
-                let latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
-                let latLng = map.unproject(latLngPoint, coords.z);
-                let lng = latLng.lng;
-                //if (debug_level >= 2) console.log("lng:", lng);
-                if (lng > xmin && lng < xmax) {
-                    //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#00FF00"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
-                    let x_in_raster_pixels = Math.floor( (lng - xmin) / pixelWidth );
+        // render asynchronously so tiles show up as they finish instead of all at once (which blocks the UI)
+        setTimeout(function () {
+            for (let h = 0; h < number_of_rectangles_down; h++) {
+                let y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
+                let latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
+                let latWest = map.unproject(latWestPoint, coords.z);
+                let lat = latWest.lat;
+                //if (debug_level >= 2) console.log("lat:", lat);
+                if (lat > ymin && lat < ymax) {
+                  let y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
+                  let y_in_raster_pixels = Math.floor( (ymax - lat) / pixelHeight );
+                  for (let w = 0; w < number_of_rectangles_across; w++) {
+                    let latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
+                    let latLng = map.unproject(latLngPoint, coords.z);
+                    let lng = latLng.lng;
+                    //if (debug_level >= 2) console.log("lng:", lng);
+                    if (lng > xmin && lng < xmax) {
+                        //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#00FF00"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
+                        let x_in_raster_pixels = Math.floor( (lng - xmin) / pixelWidth );
 
-                    if (debug_level >= 1) time_started_reading_rasters = performance.now();
-                    let values = rasters.map(raster => raster[y_in_raster_pixels][x_in_raster_pixels]);
-                    if (debug_level >= 1) duration_reading_rasters += performance.now() - time_started_reading_rasters;
-                    let color = null;
-                    if(this.options.pixelValueToColorFn) {
-                      color = this.options.pixelValueToColorFn(values[0]);
+                        if (debug_level >= 1) time_started_reading_rasters = performance.now();
+                        if (rasters) {
+                          let values = rasters.map(raster => raster[y_in_raster_pixels][x_in_raster_pixels]);
+                        } else {
+                          let values = this.georaster.getValues(/* TODO implement this */)
+                        }
+                        if (debug_level >= 1) duration_reading_rasters += performance.now() - time_started_reading_rasters;
+                        let color = null;
+                        if(this.options.pixelValueToColorFn) {
+                          color = this.options.pixelValueToColorFn(values[0]);
+                        } else {
+                          let number_of_values = values.length;
+                          if (number_of_values == 1) {
+                              let value = values[0];
+                              if (value != no_data_value) {
+                                  // color = scale( (values[0] - mins[0]) / ranges[0] ).hex();
+                                  color = scale( (values[0] - 10798) / (16110-10798)).hex();
+                              }
+                          } else if (number_of_values == 2) {
+                          } else if (number_of_values == 3) {
+                              if (values[0] != no_data_value) {
+                                  color = "rgb(" + values[0] + "," + values[1] + "," + values[2] + ")";
+                              }
+                          }
+                        }
+                        //let colors = ["red", "green", "blue", "pink", "purple", "orange"];
+                        //let color = colors[Math.round(colors.length * Math.random())];
+                        //context.fillStyle = this.getColor(color);
+                        if (color) {
+                            context.fillStyle = color;
+                            if (debug_level >= 1) time_started_filling_rect = performance.now();
+                            context.fillRect(Math.round(w * width_of_rectangle_in_pixels), y_in_tile_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int);
+                            if (debug_level >= 1) duration_filling_rects += performance.now() - time_started_filling_rect;
+                        }
+                        //if (debug_level >= 2) console.log("filling:", [w * width_of_rectangle_in_pixels, rect_y_in_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int]);
+                        //if (debug_level >= 2) console.log("with color:", color);
+                        //if (debug_level >= 2) console.log("with context:", context);
                     } else {
-                      let number_of_values = values.length;
-                      if (number_of_values == 1) {
-                          let value = values[0];
-                          if (value != no_data_value) {
-                              color = scale( (values[0] - mins[0]) / ranges[0] ).hex();
-                          }
-                      } else if (number_of_values == 2) {
-                      } else if (number_of_values == 3) {
-                          if (values[0] != no_data_value) {
-                              color = "rgb(" + values[0] + "," + values[1] + "," + values[2] + ")";
-                          }
-                      }
+                        //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#FF0000"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
                     }
-                    //let colors = ["red", "green", "blue", "pink", "purple", "orange"];
-                    //let color = colors[Math.round(colors.length * Math.random())];
-                    //context.fillStyle = this.getColor(color);
-                    if (color) {
-                        context.fillStyle = color;
-                        if (debug_level >= 1) time_started_filling_rect = performance.now();
-                        context.fillRect(Math.round(w * width_of_rectangle_in_pixels), y_in_tile_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int);
-                        if (debug_level >= 1) duration_filling_rects += performance.now() - time_started_filling_rect;
-                    }
-                    //if (debug_level >= 2) console.log("filling:", [w * width_of_rectangle_in_pixels, rect_y_in_pixels, width_of_rectangle_in_pixels_int, height_of_rectangle_in_pixels_int]);
-                    //if (debug_level >= 2) console.log("with color:", color);
-                    //if (debug_level >= 2) console.log("with context:", context);
-                } else {
-                    //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#FF0000"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
+                  }
                 }
-              }
             }
-        }
 
 
-        if (debug_level >= 1) {
-            let duration = performance.now() - start_time;
-            console.log("creating tile took ", duration, "milliseconds");
-            console.log("took", duration_reading_rasters, "milliseconds to read rasters, which is ", Math.round(duration_reading_rasters / duration * 100), "percentage of the total time");
-            console.log("took", duration_filling_rects, "milliseconds to fill rects, which is ", Math.round(duration_filling_rects / duration * 100), "percentage of the total time");
-        }
-        //if (debug_level >= 1) console.groupEnd();
+            if (debug_level >= 1) {
+                let duration = performance.now() - start_time;
+                console.log("creating tile took ", duration, "milliseconds");
+                console.log("took", duration_reading_rasters, "milliseconds to read rasters, which is ", Math.round(duration_reading_rasters / duration * 100), "percentage of the total time");
+                console.log("took", duration_filling_rects, "milliseconds to fill rects, which is ", Math.round(duration_filling_rects / duration * 100), "percentage of the total time");
+            }
+            //if (debug_level >= 1) console.groupEnd();
+
+            done(error, tile);
+        }.bind(this), 0);
 
         // return the tile so it can be rendered on screen
         return tile;

--- a/georaster-layer-for-leaflet.js
+++ b/georaster-layer-for-leaflet.js
@@ -144,7 +144,7 @@ var GeoRasterLayer = L.GridLayer.extend({
         let tileNwPoint = coords.scaleBy(tileSize);
 
         // render asynchronously so tiles show up as they finish instead of all at once (which blocks the UI)
-        setTimeout(function () {
+        setTimeout(async function () {
             for (let h = 0; h < number_of_rectangles_down; h++) {
                 let y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
                 let latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
@@ -164,10 +164,13 @@ var GeoRasterLayer = L.GridLayer.extend({
                         let x_in_raster_pixels = Math.floor( (lng - xmin) / pixelWidth );
 
                         if (debug_level >= 1) time_started_reading_rasters = performance.now();
+                        let values = null;
                         if (rasters) {
-                          let values = rasters.map(raster => raster[y_in_raster_pixels][x_in_raster_pixels]);
+                          values = rasters.map(raster => raster[y_in_raster_pixels][x_in_raster_pixels]);
                         } else {
-                          let values = this.georaster.getValues(/* TODO implement this */)
+                          console.log('doing getValues');
+                          values = await this.georaster.getValues(y_in_raster_pixels, x_in_raster_pixels);
+                          console.log('getValues done: ', values);
                         }
                         if (debug_level >= 1) duration_reading_rasters += performance.now() - time_started_reading_rasters;
                         let color = null;

--- a/georaster-layer-for-leaflet.js
+++ b/georaster-layer-for-leaflet.js
@@ -56,9 +56,56 @@ var GeoRasterLayer = L.GridLayer.extend({
             console.error("ERROR initializing GeoTIFFLayer", error);
         }
     },
+    
+    getRasters: async function(
+          map, tileNwPoint, height_of_rectangle_in_pixels, width_of_rectangle_in_pixels,
+          coords, pixelHeight, pixelWidth, number_of_rectangles_across, number_of_rectangles_down, ymax, xmin) {
+      // called if georaster was constructed from URL and we need to get
+      // data separately for each tile
+      // aka "COG mode"
+
+      const raster_coords_for_tile_coords = function(h, w) {
+        let y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
+        let latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
+        let latWest = map.unproject(latWestPoint, coords.z);
+        let lat = latWest.lat;
+        let y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
+        let y_in_raster_pixels = Math.floor( (ymax - lat) / pixelHeight );
+
+        let latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
+        let latLng = map.unproject(latLngPoint, coords.z);
+        let lng = latLng.lng;
+        let x_in_raster_pixels = Math.floor( (lng - xmin) / pixelWidth );
+
+        return [y_in_raster_pixels, x_in_raster_pixels];
+      }
+
+      let result = raster_coords_for_tile_coords(0, 0);
+      let min_y = result[0];
+      let min_x = result[1];
+      result = raster_coords_for_tile_coords(number_of_rectangles_down - 1, number_of_rectangles_across - 1);
+      let max_y = result[0];
+      let max_x = result[1];
+
+      // careful not to flip min_y/max_y here
+      let tile_values = await this.georaster.getValues(min_x, min_y, max_x, max_y, number_of_rectangles_across, number_of_rectangles_down);
+
+      let tile_values_2d = tile_values.map(valuesInOneDimension => {
+        const valuesInTwoDimensions = [];
+        const width = number_of_rectangles_across;
+        const height = number_of_rectangles_down;
+        for (let y = 0; y < height; y++) {
+          const start = y * width;
+          const end = start + width;
+          valuesInTwoDimensions.push(valuesInOneDimension.slice(start, end));
+        }
+        return valuesInTwoDimensions;
+      });
+
+      return tile_values_2d;
+    },
 
     createTile: function(coords, done) {
-    // createTile: function(coords) {
 
         var error;
 
@@ -143,97 +190,12 @@ var GeoRasterLayer = L.GridLayer.extend({
 
         // render asynchronously so tiles show up as they finish instead of all at once (which blocks the UI)
         setTimeout(async function () {
-            let min_x = Number.MAX_SAFE_INTEGER;
-            let max_x = 0;
-            let min_y = Number.MAX_SAFE_INTEGER;
-            let max_y = 0;
-
-            let samples_per_pixel = null;
-            let tile_values = [];
-            if (rasters) {
-              samples_per_pixel = rasters.length;
-              for (let samp_i = 0; samp_i < samples_per_pixel; samp_i++) {
-                tile_values.push([]);
-              }
-            }
-
-            const push_value = function(value_array, values) {
-                for (let val_i = 0; val_i < samples_per_pixel; val_i++) {
-                  let value = no_data_value;
-                  if (values) {
-                    value = values[val_i];
-                  }
-                  value_array[val_i].push(value)
-                }
-            }
-
-            for (let h = 0; h < number_of_rectangles_down; h++) {
-                let y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
-                let latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
-                let latWest = map.unproject(latWestPoint, coords.z);
-                let lat = latWest.lat;
-                //if (debug_level >= 2) console.log("lat:", lat);
-                if ((!rasters) || (lat > ymin && lat < ymax)) {
-                  let y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
-                  let y_in_raster_pixels = Math.floor( (ymax - lat) / pixelHeight );
-                  for (let w = 0; w < number_of_rectangles_across; w++) {
-                    let latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
-                    let latLng = map.unproject(latLngPoint, coords.z);
-                    let lng = latLng.lng;
-                    //if (debug_level >= 2) console.log("lng:", lng);
-                    if ((!rasters) || (lng > xmin && lng < xmax)) {
-                        //if (debug_level >= 2) L.circleMarker([lat, lng], {color: "#00FF00"}).bindTooltip(h+","+w).addTo(this._map).openTooltip();
-                        let x_in_raster_pixels = Math.floor( (lng - xmin) / pixelWidth );
-
-                        if (debug_level >= 1) time_started_reading_rasters = performance.now();
-                        if (rasters) {
-                          let values = rasters.map(raster => raster[y_in_raster_pixels][x_in_raster_pixels]);
-                          push_value(tile_values, values);
-                        } else {
-                          if (y_in_raster_pixels < min_y) {
-                            min_y = y_in_raster_pixels;
-                          }
-                          if (y_in_raster_pixels > max_y) {
-                            max_y = y_in_raster_pixels;
-                          }
-                          if (x_in_raster_pixels < min_x) {
-                            min_x = x_in_raster_pixels;
-                          }
-                          if (x_in_raster_pixels > max_x) {
-                            max_x = x_in_raster_pixels;
-                          }
-                        }
-                    } else {
-                        if (rasters) {
-                          push_value(tile_values);
-                        }
-                    }
-                  }
-                } else {
-                    if (rasters) {
-                      for (let w = 0; w < number_of_rectangles_across; w++) {
-                        push_value(tile_values);
-                      }
-                    }
-                }
-            }
-
+            let tile_rasters = null;
             if (!rasters) {
-              // careful not to flip min_y/max_y here
-              tile_values = await this.georaster.getValues(min_x, min_y, max_x, max_y, number_of_rectangles_across, number_of_rectangles_down);
+              tile_rasters = await this.getRasters(
+                map, tileNwPoint, height_of_rectangle_in_pixels, width_of_rectangle_in_pixels, coords, pixelHeight, pixelWidth,
+                number_of_rectangles_across, number_of_rectangles_down, ymax, xmin);
             }
-
-            let tile_values_2d = tile_values.map(valuesInOneDimension => {
-              const valuesInTwoDimensions = [];
-              const width = number_of_rectangles_across;
-              const height = number_of_rectangles_down;
-              for (let y = 0; y < height; y++) {
-                const start = y * width;
-                const end = start + width;
-                valuesInTwoDimensions.push(valuesInOneDimension.slice(start, end));
-              }
-              return valuesInTwoDimensions;
-            });
 
             for (let h = 0; h < number_of_rectangles_down; h++) {
                 let y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
@@ -254,8 +216,16 @@ var GeoRasterLayer = L.GridLayer.extend({
                         let x_in_raster_pixels = Math.floor( (lng - xmin) / pixelWidth );
 
                         if (debug_level >= 1) time_started_reading_rasters = performance.now();
-                        let values = tile_values_2d.map(raster => raster[h][w]);
+                        let values = null;
+                        if (tile_rasters) {
+                          // get value from array specific to this tile
+                          values = tile_rasters.map(raster => raster[h][w]);
+                        } else {
+                          // get value from array with data for entire raster
+                          values = rasters.map(raster => raster[y_in_raster_pixels][x_in_raster_pixels]);
+                        }
                         if (debug_level >= 1) duration_reading_rasters += performance.now() - time_started_reading_rasters;
+
                         let color = null;
                         if(this.options.pixelValueToColorFn) {
                           color = this.options.pixelValueToColorFn(values[0]);

--- a/georaster-layer-for-leaflet.js
+++ b/georaster-layer-for-leaflet.js
@@ -200,7 +200,7 @@ var GeoRasterLayer = L.GridLayer.extend({
                     } else {
                         if (rasters) {
                           for (let val_i = 0; val_i < samples_per_pixel; val_i++) {
-                            tile_values[val_i].push(0);
+                            tile_values[val_i].push(no_data_value);
                           }
                         }
                     }
@@ -209,7 +209,7 @@ var GeoRasterLayer = L.GridLayer.extend({
                     if (rasters) {
                       for (let w = 0; w < number_of_rectangles_across; w++) {
                         for (let val_i = 0; val_i < samples_per_pixel; val_i++) {
-                          tile_values[val_i].push(0);
+                          tile_values[val_i].push(no_data_value);
                         }
                       }
                     }

--- a/georaster-layer-for-leaflet.js
+++ b/georaster-layer-for-leaflet.js
@@ -36,6 +36,12 @@ var GeoRasterLayer = L.GridLayer.extend({
             this._xmax = georaster.xmax;
             this._ymax = georaster.ymax;
 
+            if (georaster.sourceType === 'url' && georaster.numberOfRasters === 1 && !options.pixelValueToColorFn) {
+              // For COG, we can't determine a data min max for color scaling,
+              // so pixelValueToColorFn is required.
+              throw "pixelValueToColorFn is a required option for single-band rasters initialized via URL";
+            }
+
             console.log("georaster.ymin:", georaster.ymin);
             let southWest = L.latLng(georaster.ymin, georaster.xmin);
             let northEast = L.latLng(georaster.ymax, georaster.xmax);
@@ -233,14 +239,8 @@ var GeoRasterLayer = L.GridLayer.extend({
                           let number_of_values = values.length;
                           if (number_of_values == 1) {
                               let value = values[0];
-                              if (ranges) {
-                                if (value != no_data_value) {
-                                    color = scale( (values[0] - mins[0]) / ranges[0] ).hex();
-                                }
-                              } else {
-                                // TODO not sure what to do here - For COG, we don't know the min max of the full raster.
-                                // Currently I'm just hardcoding to a value that works for the LS8 raster I'm looking at.
-                                color = scale( (values[0] - 10798) / (16110-10798)).hex();
+                              if (value != no_data_value) {
+                                  color = scale( (values[0] - mins[0]) / ranges[0] ).hex();
                               }
                           } else if (number_of_values == 2) {
                           } else if (number_of_values == 3) {

--- a/georaster-layer-for-leaflet.js
+++ b/georaster-layer-for-leaflet.js
@@ -74,24 +74,22 @@ var GeoRasterLayer = L.GridLayer.extend({
         let y_center_in_map_pixels = tileNwPoint.y + (h + 0.5) * height_of_rectangle_in_pixels;
         let latWestPoint = L.point(tileNwPoint.x, y_center_in_map_pixels);
         let latWest = map.unproject(latWestPoint, coords.z);
-        let lat = latWest.lat;
+        let { lat } = latWest;
         let y_in_tile_pixels = Math.round(h * height_of_rectangle_in_pixels);
         let y_in_raster_pixels = Math.floor( (ymax - lat) / pixelHeight );
 
         let latLngPoint = L.point(tileNwPoint.x + (w + 0.5) * width_of_rectangle_in_pixels, y_center_in_map_pixels);
         let latLng = map.unproject(latLngPoint, coords.z);
-        let lng = latLng.lng;
+        let { lng } = latLng;
         let x_in_raster_pixels = Math.floor( (lng - xmin) / pixelWidth );
 
         return [y_in_raster_pixels, x_in_raster_pixels];
       }
 
       let result = raster_coords_for_tile_coords(0, 0);
-      let min_y = result[0];
-      let min_x = result[1];
+      let [ min_y, min_x ] = result;
       result = raster_coords_for_tile_coords(number_of_rectangles_down - 1, number_of_rectangles_across - 1);
-      let max_y = result[0];
-      let max_x = result[1];
+      let [ max_y, max_x ] = result;
 
       // careful not to flip min_y/max_y here
       let tile_values = await this.georaster.getValues(min_x, min_y, max_x, max_y, number_of_rectangles_across, number_of_rectangles_down);

--- a/georaster-layer-for-leaflet.js
+++ b/georaster-layer-for-leaflet.js
@@ -144,7 +144,7 @@ var GeoRasterLayer = L.GridLayer.extend({
         let tileNwPoint = coords.scaleBy(tileSize);
 
         // render asynchronously so tiles show up as they finish instead of all at once (which blocks the UI)
-        setTimeout(async function () {
+        (async function () {
             let min_x = Number.MAX_SAFE_INTEGER;
             let max_x = 0;
             let min_y = Number.MAX_SAFE_INTEGER;
@@ -301,7 +301,7 @@ var GeoRasterLayer = L.GridLayer.extend({
             //if (debug_level >= 1) console.groupEnd();
 
             done(error, tile);
-        }.bind(this), 0);
+        }.bind(this))();
 
         // return the tile so it can be rendered on screen
         return tile;


### PR DESCRIPTION
Hi @DanielJDufour, this is a first stab at an implementation for #10 . There is probably some cleanup worth doing but I wanted to get your thoughts on whether I'm headed in the right direction.

The basic strategy is:
If the georaster was constructed form a URL, then for each tile determine the extent and dimensions needed to render that tile, and make a single `georaster.getValues` to get the data needed for the tile being rendered. The render loop is now split into two loops: a first pass to determine the extent for the `getValues` call, and a second pass to actually do the rendering as before.

Note, if the georaster had been constructed from a data array, things work essentially the same as before, though the implementation has been altered slightly to better match how I'm doing things for COG (for each tile, build up a 1D array with needed values, then loop over the values again to render them).

One other change is to do the createTile asynchronously which seems to improve browser performance (tiles appear in browser as they finish instead of all at once).

Note this depends on the following georaster PR:
https://github.com/GeoTIFF/georaster/pull/31

Let me know if you think this is headed in the right direction and if you have any suggestions! Thanks!