### PR TITLE
Fix debug log level check

### DIFF
--- a/georaster-layer-for-leaflet.js
+++ b/georaster-layer-for-leaflet.js
@@ -62,7 +62,7 @@ const GeoRasterLayer = L.GridLayer.extend({
         if (!options.keepBuffer) options.keepBuffer = 16;
       }
 
-      if (!options.debugLevel) options.debugLevel = 1;
+      if (!('debugLevel' in options)) options.debugLevel = 1;
       if (!options.keepBuffer) options.keepBuffer = 25;
       if (!options.resolution) options.resolution = Math.pow(2, 5);
       if (options.updateWhenZooming === undefined) options.updateWhenZooming = false;


### PR DESCRIPTION
Check presence for `debugLevel` key in options using the `in` operator. Using `!options.debugLevel` returns `false` for `0` as an option and does not turn off logging.