### PR TITLE
reduce raster pixel aliasing at high zoom levels

### DIFF
--- a/src/georaster-layer-for-leaflet.ts
+++ b/src/georaster-layer-for-leaflet.ts
@@ -427,10 +427,10 @@ const GeoRasterLayer: (new (options: GeoRasterLayerOptions) => any) & typeof L.C
       const maxNumberOfSamplesDown = Math.ceil(percentHeight * resolution);
       if (debugLevel >= 4) console.log({ maxNumberOfSamplesAcross, maxNumberOfSamplesDown });
 
-      // prevent sampling more times than number of pixels to display
-      const numberOfSamplesAcross = Math.min(maxNumberOfSamplesAcross, rasterPixelsAcross);
+      // limit repeat sampling of the same pixel but also reducing aliasing at high zoom
+      const numberOfSamplesAcross = Math.min(maxNumberOfSamplesAcross, 3 * rasterPixelsAcross);
       if (debugLevel >= 4) console.log({ resolution, rasterPixelsAcross, numberOfSamplesAcross });
-      const numberOfSamplesDown = Math.min(maxNumberOfSamplesDown, rasterPixelsDown);
+      const numberOfSamplesDown = Math.min(maxNumberOfSamplesDown, 3 * rasterPixelsDown);
 
       // set how large to display each sample in screen pixels
       const heightOfSampleInScreenPixels = innerTileHeight / numberOfSamplesDown;


### PR DESCRIPTION
If the number of samples is limited to the number of raster pixels intersecting a tile, then at high zoom levels some neighboring pixels will both sample the same raster pixel, with this aliasing resulting in very visible doubled pixels. Increasing the maximum number of samples by a factor of three in each dimension reduces this effect as the doubled samples are a third of the raster pixel size. The only performance impact is at high zoom levels where doubled pixels would otherwise be visible, and performance is still no worse than at low zoom levels.