### PR TITLE
Add resolution based on zoom levels

### DIFF
--- a/src/georaster-layer-for-leaflet.ts
+++ b/src/georaster-layer-for-leaflet.ts
@@ -413,11 +413,11 @@ const GeoRasterLayer: (new (options: GeoRasterLayerOptions) => any) & typeof L.C
         // pad xmax and ymin of container to tolerate ceil() and floor() in snap()
         container: inSimpleCRS
           ? [
-            extentOfLayer.xmin,
-            extentOfLayer.ymin - 0.25 * pixelHeight,
-            extentOfLayer.xmax + 0.25 * pixelWidth,
-            extentOfLayer.ymax
-          ]
+              extentOfLayer.xmin,
+              extentOfLayer.ymin - 0.25 * pixelHeight,
+              extentOfLayer.xmax + 0.25 * pixelWidth,
+              extentOfLayer.ymax
+            ]
           : [xmin, ymin - 0.25 * pixelHeight, xmax + 0.25 * pixelWidth, ymax],
         debug: debugLevel >= 2,
         origin: inSimpleCRS ? [extentOfLayer.xmin, extentOfLayer.ymax] : [xmin, ymax],
@@ -441,8 +441,28 @@ const GeoRasterLayer: (new (options: GeoRasterLayerOptions) => any) & typeof L.C
         const recropTileProj = inSimpleCRS ? recropTileOrig : recropTileOrig.reproj(code);
         const recropTile = recropTileProj.crop(extentOfTileInMapCRS);
         if (recropTile !== null) {
-          maxSamplesAcross = Math.ceil(resolution * (recropTile.width / extentOfTileInMapCRS.width));
-          maxSamplesDown = Math.ceil(resolution * (recropTile.height / extentOfTileInMapCRS.height));
+          let resolutionValue;
+
+          if (typeof resolution === "object") {
+            const zoomLevels = Object.keys(resolution);
+            const mapZoom = this.getMap().getZoom();
+
+            for (const key in zoomLevels) {
+              if (Object.prototype.hasOwnProperty.call(zoomLevels, key)) {
+                const zoomLvl = zoomLevels[key];
+                if (zoomLvl <= mapZoom) {
+                  resolutionValue = resolution[zoomLvl];
+                } else {
+                  break;
+                }
+              }
+            }
+          } else {
+            resolutionValue = resolution;
+          }
+
+          maxSamplesAcross = Math.ceil(resolutionValue * (recropTile.width / extentOfTileInMapCRS.width));
+          maxSamplesDown = Math.ceil(resolutionValue * (recropTile.height / extentOfTileInMapCRS.height));
         }
       }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,7 +18,7 @@ export type SimplePoint = {
 export type Mask = Feature | FeatureCollection | Polygon | MultiPolygon;
 
 interface GeoRasterLayerOptions_CommonOptions extends GridLayerOptions {
-  resolution?: number;
+  resolution?: number | { [key: number]: number };
   debugLevel?: DebugLevel;
   pixelValuesToColorFn?: PixelValuesToColorFn;
   bounds?: LatLngBounds;


### PR DESCRIPTION
This feature makes it possible that the GeoTIFF is rendered differently based on the zoom level. This has the benefit, that we have a much better performance while moving the map and still having a high resolution on a high zoom level.

Example:
Resolution from zoom level 0 and higher is 32, if zoom is 10 or higher the resolution is 100 and from 18 and higher it is 200.

```
var layer = new GeoRasterLayer({
    georaster: georaster,
    resolution: {
        0: 32,
        10: 100,
        18: 200
    }
});
```