### PR TITLE
Fix zoom and add test for resolution based on zoom

### DIFF
--- a/src/georaster-layer-for-leaflet.ts
+++ b/src/georaster-layer-for-leaflet.ts
@@ -445,12 +445,11 @@ const GeoRasterLayer: (new (options: GeoRasterLayerOptions) => any) & typeof L.C
 
           if (typeof resolution === "object") {
             const zoomLevels = Object.keys(resolution);
-            const mapZoom = this.getMap().getZoom();
 
             for (const key in zoomLevels) {
               if (Object.prototype.hasOwnProperty.call(zoomLevels, key)) {
                 const zoomLvl = zoomLevels[key];
-                if (zoomLvl <= mapZoom) {
+                if (zoomLvl <= zoom) {
                   resolutionValue = resolution[zoomLvl];
                 } else {
                   break;

--- a/tests/resolution-zoom.html
+++ b/tests/resolution-zoom.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+    <style>
+      #map {
+        bottom: 0;
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <script src="https://unpkg.com/browse/whatwg-fetch@3.2.0/dist/fetch.umd.js"></script>
+    <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/georaster"></script>
+    <script src="../dist/georaster-layer-for-leaflet.min.js"></script>
+    <script>
+      // initalize leaflet map
+      var map = L.map("map").setView([0, 0], 5);
+
+      // add OpenStreetMap basemap
+      L.tileLayer("http://{s}.tile.osm.org/{z}/{x}/{y}.png", {
+        attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      }).addTo(map);
+
+      var url_to_geotiff_file = "https://geotiff.github.io/georaster-layer-for-leaflet-example/example_4326.tif";
+
+      fetch(url_to_geotiff_file)
+        .then(function (response) {
+          return response.arrayBuffer();
+        })
+        .then(function (arrayBuffer) {
+          parseGeoraster(arrayBuffer).then(function (georaster) {
+            console.log("georaster:", georaster);
+            var layer = new GeoRasterLayer({
+              georaster: georaster,
+              resolution: {
+                0: 2, // Zoom level 0 or higher: resolution 2
+                16: 512 // Zoom level 16 or higher: resolution 512
+              }
+            });
+            layer.addTo(map);
+            map.fitBounds(layer.getBounds());
+          });
+        });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
I added a test and also found a bug. Problem was, that `map.getZoom()` always returns the zoomlevel before zooming. 