### PR TITLE
Allow PixelValuesToColorFn to return null values

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,7 @@ import type { Feature, FeatureCollection, Polygon, MultiPolygon } from "geojson"
 
 export type MaskStrategy = "inside" | "outside";
 
-export type PixelValuesToColorFn = (values: number[]) => string;
+export type PixelValuesToColorFn = (values: number[]) => string | null;
 
 export type DebugLevel = 0 | 1 | 2 | 3 | 4 | 5;
 


### PR DESCRIPTION
**Some context:** Before the v4 release, I was able to return an empty string in my Typescript code to get around this issue, and it did not render these tiles (or at least, those pixels did not show up, maybe they still got rendered but hidden or something). Now when a `''` value is returned, it'll color the pixels black (I sort of can see why, no color values === black), but it yield weird results with other correct pixels in the same tile (see screenshot)

This now also corresponds to the returned values in some of the test files.

<img width="483" alt="image" src="https://github.com/GeoTIFF/georaster-layer-for-leaflet/assets/13683094/4308b843-c58f-481a-8051-21799047c90e">
