### PR TITLE
Ensure that each instance has its unique cache object

### DIFF
--- a/src/georaster-layer-for-leaflet.ts
+++ b/src/georaster-layer-for-leaflet.ts
@@ -87,9 +87,8 @@ const GeoRasterLayer: (new (options: GeoRasterLayerOptions) => any) & typeof L.C
     turbo: false
   },
 
-  cache: {},
-
   initialize: function (options: GeoRasterLayerOptions) {
+    this.cache = {};
     this.proj4 = proj4collect();
 
     try {


### PR DESCRIPTION
The cache object should be initialized inside the initialize function otherwise all instances of the `GeoRasterLayer` class will share the same cache object.

An example to demonstrate.

```html
<!DOCTYPE html>
<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
    integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
<script>
    var SharedCache = L.Class.extend({
        cache: {},
        add: function (key, value) {
            this.cache[key] = value;
        },
    });

    var sc_1 = new SharedCache();
    sc_1.add('key1', 'value1');
    console.log(sc_1.cache);

    var sc_2 = new SharedCache();
    console.log(sc_2.cache);

    console.log(sc_1.cache == sc_2.cache); // true

    var PrivateCache = L.Class.extend({
        initialize: function () {
            this.cache = {};
        },
        add: function (key, value) {
            this.cache[key] = value;
        },
    });

    var pc_1 = new PrivateCache();
    pc_1.add('key1', 'value1');
    console.log(pc_1.cache);

    var pc_2 = new PrivateCache();
    console.log(pc_2.cache);

    console.log(pc_1.cache == pc_2.cache); // false
</script>
```